### PR TITLE
send WILL ATCP on DO ATCP

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -3241,6 +3241,9 @@ static int handle_socket_input(const char *simbuffer, int simlen)
                 } else if (
                     rawchar == TN_NAWS ||
                     rawchar == TN_TTYPE ||
+#if ENABLE_ATCP
+		    (rawchar == TN_ATCP && atcp) ||
+#endif
                     rawchar == TN_BINARY)
                 {
                     SET_TELOPT(xsock, us, rawchar);  /* set state */


### PR DESCRIPTION
The german mud avalon (avalon.mud.de) sends a DO ATCP request instead of a WILL ATCP. This patch responds with a WILL ATCP on DO ATCP requests.
