### PR TITLE
Recognize ansi codes 39m,49m for set default fg,bg

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -538,6 +538,8 @@ String *decode_ansi(const char *s, attr_t attrs, int emul, attr_t *final_attrs)
                     case 24:  new &= ~F_UNDERLINE;    break;
                     case 25:  new &= ~F_FLASH;        break;
                     case 27:  new &= ~F_REVERSE;      break;
+                    case 39:  new &= ~F_FGCOLOR;      break;
+                    case 49:  new &= ~F_BGCOLOR;      break;
                     default:  /* ignore it */         break;
                 }
             } while (s[0] == ';' && s[1]);


### PR DESCRIPTION
* Recognize 39m for 'set foreground color to default'
* Recognize 49m for 'set background color to default'

In using color support on my server, I found tf wasn't ending the foreground color properly; the color continued past where it should.  If I altered the server to send also `0m` to completely reset attributes, that worked; but the server was normally sending `39m` to reset just the foreground color, and tf wasn't honoring/recognizing that.

This patch appears to be all that's necessary to recognize `39m`; and while I was in there I added also recognizing `49m` for resetting of background color.

As a test example for reference, on the server (node.js using [chalk](/chalk/chalk)):

```
send(chalk.blue('blue'));
send('none');
send(chalk.bgBlue.white('bgblue'));
send('none');
```

tf (with normal `/set emulation ansi_attr`) gave:

![screen shot 2018-09-14 at 10 14 12 pm](https://user-images.githubusercontent.com/18635433/45582064-2b2c3c00-b86f-11e8-9059-4daba7e70d03.png)

while the expected being:

![screen shot 2018-09-14 at 10 15 12 pm](https://user-images.githubusercontent.com/18635433/45582094-9544e100-b86f-11e8-9c61-f3fc41d092b2.png)

which is what occurs with plain telnet, tf with `/set emulation raw`, or tf `/set emulation ansi_attr` plus this patch.