### PR TITLE
Allow for python > 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7]
+        python-version: [3.7, 3.8, 3.9]
         opts: 
           - ""
           - "--enable-python"

--- a/configure
+++ b/configure
@@ -4792,7 +4792,7 @@ done
 
    ax_python_conf=$PYTHON_CONF
    ax_python_lib=`$ax_python_conf --embed --ldflags`
-   if test "x$ax_python_lib" = "x"; then
+   if [ $? -ne 0 ]; then
        ax_python_lib=`$ax_python_config --ldflags`
    fi 
    ax_python_header=`$ax_python_conf --includes`

--- a/configure
+++ b/configure
@@ -4793,7 +4793,7 @@ done
    ax_python_conf=$PYTHON_CONF
    ax_python_lib=`$ax_python_conf --embed --ldflags`
    if [ $? -ne 0 ]; then
-       ax_python_lib=`$ax_python_config --ldflags`
+       ax_python_lib=`$ax_python_conf --ldflags`
    fi 
    ax_python_header=`$ax_python_conf --includes`
    if test "x$ax_python_header" != "x"; then

--- a/configure
+++ b/configure
@@ -4703,7 +4703,7 @@ if test "$enable_python" = "yes"; then
 $as_echo_n "checking for python build information... " >&6; }
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: " >&5
 $as_echo "" >&6; }
-for python in python3 python python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0; do
+for python in python3 python python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0; do
 for ac_prog in $python
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
@@ -4791,7 +4791,10 @@ fi
 done
 
    ax_python_conf=$PYTHON_CONF
-   ax_python_lib=`$ax_python_conf --ldflags`
+   ax_python_lib=`$ax_python_conf --embed --ldflags`
+   if test "x$ax_python_lib" = "x"; then
+       ax_python_lib=`$ax_python_config --ldflags`
+   fi 
    ax_python_header=`$ax_python_conf --includes`
    if test "x$ax_python_header" != "x"; then
        break;

--- a/m4/ax_python.m4
+++ b/m4/ax_python.m4
@@ -64,7 +64,7 @@ if test x$ax_python_bin != x; then
    ax_python_conf=$PYTHON_CONF
    ax_python_lib=`$ax_python_conf --embed --ldflags`
    if [ $? -ne 0 ]; then
-       ax_python_lib=`$ax_python_config --ldflags`
+       ax_python_lib=`$ax_python_conf --ldflags`
    fi   
    ax_python_header=`$ax_python_conf --includes`
    if test "x$ax_python_header" != "x"; then

--- a/m4/ax_python.m4
+++ b/m4/ax_python.m4
@@ -56,13 +56,16 @@
 AC_DEFUN([AX_PYTHON],
 [AC_MSG_CHECKING(for python build information)
 AC_MSG_RESULT([])
-for python in python3 python python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0; do
+for python in python3 python python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0; do
 AC_CHECK_PROGS(PYTHON_BIN, [$python])
 ax_python_bin=$PYTHON_BIN
 if test x$ax_python_bin != x; then
    AC_CHECK_PROGS(PYTHON_CONF, [$python-config])
    ax_python_conf=$PYTHON_CONF
-   ax_python_lib=`$ax_python_conf --ldflags`
+   ax_python_lib=`$ax_python_conf --embed --ldflags`
+   if test "x$ax_python_lib" = "x"; then
+       ax_python_lib=`$ax_python_config --ldflags`
+   fi   
    ax_python_header=`$ax_python_conf --includes`
    if test "x$ax_python_header" != "x"; then
        break;

--- a/m4/ax_python.m4
+++ b/m4/ax_python.m4
@@ -63,7 +63,7 @@ if test x$ax_python_bin != x; then
    AC_CHECK_PROGS(PYTHON_CONF, [$python-config])
    ax_python_conf=$PYTHON_CONF
    ax_python_lib=`$ax_python_conf --embed --ldflags`
-   if test "x$ax_python_lib" = "x"; then
+   if [ $? -ne 0 ]; then
        ax_python_lib=`$ax_python_config --ldflags`
    fi   
    ax_python_header=`$ax_python_conf --includes`

--- a/src/command.c
+++ b/src/command.c
@@ -218,7 +218,7 @@ struct Value *handle_quit_command(String *args, int offset)
         else return shareval(val_zero);
     }
 
-    if (interactive && have_active_socks() && !yes) {
+    if (tfinteractive && have_active_socks() && !yes) {
 	fix_screen();
 	puts("There are sockets with unseen text.  Really quit tf? (y/N)\r");
 	fflush(stdout);

--- a/src/globals.h
+++ b/src/globals.h
@@ -191,7 +191,7 @@ enum Vars {
 #define iecho		getintvar(VAR_iecho)
 #define info_attr	getattrvar(VAR_info_attr)
 #define insert		getintvar(VAR_insert)
-#define interactive	getintvar(VAR_interactive)
+#define tfinteractive	getintvar(VAR_interactive)
 #define isize		getintvar(VAR_isize)
 #define istrip		getintvar(VAR_istrip)
 #define kbnum		getstrvar(VAR_kbnum)

--- a/src/output.c
+++ b/src/output.c
@@ -2887,7 +2887,7 @@ void reset_outcount(Screen *screen)
 /* return TRUE if okay to print */
 static int check_more(Screen *screen)
 {
-    if (!screen->paused && more && interactive && screen->outcount-- <= 0)
+    if (!screen->paused && more && tfinteractive && screen->outcount-- <= 0)
     {
         /* status bar is updated in oflush() to avoid scroll region problems */
         screen->paused = 1;

--- a/src/signals.c
+++ b/src/signals.c
@@ -269,7 +269,7 @@ static void handle_interrupt(void)
     VEC_CLR(SIGINT, &pending_signals);
     /* so status line macros in setup_screen() aren't gratuitously killed */
 
-    if (!interactive)
+    if (!tfinteractive)
         die("Interrupt, exiting.", 0);
     reset_kbnum();
     fix_screen();
@@ -316,7 +316,7 @@ static RETSIGTYPE core_handler(int sig)
     setsighandler(sig, core_handler);  /* restore handler (POSIX) */
 
     if (sig == SIGQUIT) {
-	if (interactive) {
+	if (tfinteractive) {
 	    fix_screen();
 #if DISABLE_CORE
 	    puts("SIGQUIT received.  Exit?  (y/n)\r");
@@ -372,7 +372,7 @@ static RETSIGTYPE core_handler(int sig)
 	}
     }
 
-    if (interactive) {
+    if (tfinteractive) {
 	close_all();
         fputs("\nPress any key.\r\n", stderr);
         fflush(stderr);
@@ -636,7 +636,7 @@ int shell(const char *cmd)
     cbreak_noecho_mode();
     if (result == -1) {
         eprintf("%s", strerror(errno));
-    } else if (shpause && interactive) {
+    } else if (shpause && tfinteractive) {
         puts("\r\n% Press any key to continue tf.\r");
         igetchar();
     }


### PR DESCRIPTION
Add support for python 3.8 and 3.9

Had to rename internal definition of interactive macro to tfinteractive.
The original name causes a problem with python3.8 headers, which include
a member 'int interactive;' in the PyConfig struct.