### PR TITLE
Fix warnings

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -360,7 +360,7 @@ int handle_echo_func(
             return 0;
     }
     if (raw) {
-        write(STDOUT_FILENO, src->data, src->len);
+        size_t w_len = write(STDOUT_FILENO, src->data, src->len);
         return 1;
     }
 

--- a/src/command.c
+++ b/src/command.c
@@ -523,7 +523,7 @@ int do_file_load(const char *args, int tinytalk, char **savename)
 		    Stringadd(libfile, *path++);
 		}
 		if (!is_absolute_path(libfile->data)) {
-		    tf_wprintf((const wchar_t *)"invalid directory in TFPATH: %S", libfile);
+		    tf_wprintf("invalid directory in TFPATH: %S", libfile);
 		} else {
 		    Sappendf(libfile, "/%s", args);
 		    file = tfopen(expand_filename(libfile->data), "r");
@@ -531,7 +531,7 @@ int do_file_load(const char *args, int tinytalk, char **savename)
 	    } while (!file && *path);
 	} else {
 	    if (!is_absolute_path(TFLIBDIR)) {
-		tf_wprintf((const wchar_t *)"invalid TFLIBDIR: %s", TFLIBDIR);
+		tf_wprintf("invalid TFLIBDIR: %s", TFLIBDIR);
 	    } else {
 		Sprintf(libfile, "%s/%s", TFLIBDIR, args);
 		file = tfopen(expand_filename(libfile->data), "r");
@@ -590,7 +590,7 @@ int do_file_load(const char *args, int tinytalk, char **savename)
                 i = line->len - 1;
                 while (i > 0 && is_space(line->data[i])) i--;
                 if (line->data[i] == '\\')
-                    tf_wprintf((const wchar_t *)"whitespace following final '\\'");
+                    tf_wprintf("whitespace following final '\\'");
             }
         } else {
             last_cmd_line = 0;


### PR DESCRIPTION
If you compile it now, you get these warnings:

```
gcc -g -O2  -DDATADIR=/home/thestranjer/share      -c -o command.o command.c
command.c: In function ‘do_file_load’:
command.c:526:18: warning: passing argument 1 of ‘tf_wprintf’ from incompatible pointer type [-Wincompatible-pointer-types]
  526 |       tf_wprintf((const wchar_t *)"invalid directory in TFPATH: %S", libfile);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                  |
      |                  const wchar_t * {aka const int *}
In file included from command.c:19:
tfio.h:155:38: note: expected ‘const char *’ but argument is of type ‘const wchar_t *’ {aka ‘const int *’}
  155 | extern void   tf_wprintf(const char *fmt, ...) format_printf(1, 2);
      |                          ~~~~~~~~~~~~^~~
command.c:534:14: warning: passing argument 1 of ‘tf_wprintf’ from incompatible pointer type [-Wincompatible-pointer-types]
  534 |   tf_wprintf((const wchar_t *)"invalid TFLIBDIR: %s", TFLIBDIR);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |              |
      |              const wchar_t * {aka const int *}
In file included from command.c:19:
tfio.h:155:38: note: expected ‘const char *’ but argument is of type ‘const wchar_t *’ {aka ‘const int *’}
  155 | extern void   tf_wprintf(const char *fmt, ...) format_printf(1, 2);
      |                          ~~~~~~~~~~~~^~~
command.c:593:32: warning: passing argument 1 of ‘tf_wprintf’ from incompatible pointer type [-Wincompatible-pointer-types]
  593 |                     tf_wprintf((const wchar_t *)"whitespace following final '\\'");
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                |
      |                                const wchar_t * {aka const int *}
In file included from command.c:19:
tfio.h:155:38: note: expected ‘const char *’ but argument is of type ‘const wchar_t *’ {aka ‘const int *’}
  155 | extern void   tf_wprintf(const char *fmt, ...) format_printf(1, 2);
      |                          ~~~~~~~~~~~~^~~
command.c: In function ‘handle_echo_func’:
command.c:363:9: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
  363 |         write(STDOUT_FILENO, src->data, src->len);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

These two commits rectify that.