### PR TITLE
Requires WIDECHAR when using Unicode with Python

### DIFF
--- a/src/tfpython.c
+++ b/src/tfpython.c
@@ -220,12 +220,14 @@ static struct Value* pyvar_to_tfvar( PyObject *pRc )
 	if( PyBytes_Check( pRc ) && ( PyBytes_AsStringAndSize( pRc, &cstr, &len ) != -1 ) ) {
 		DPRINTF( "  rc string: %s", cstr );
 		rc = newstr( cstr, len );
+#if WIDECHAR
 	} else if( PyUnicode_Check( pRc) ) {
 		PyObject* temp = PyUnicode_AsASCIIString( pRc );
 		PyBytes_AsStringAndSize( temp, &cstr, &len );
 		DPRINTF( "  rc unicode: %s", cstr );
 		rc = newstr( cstr, len );
 		Py_XDECREF(temp);
+#endif
 	} else if( PyLong_Check( pRc ) ) {
 		DPRINTF( "  rc long: %ld", PyLong_AsLong( pRc ) );
 		rc = newint( PyLong_AsLong( pRc ) );


### PR DESCRIPTION
This addition to Python uses Unicode, which is what WIDECHAR enables. If you're attempting to using --enable-python and -disable-widechar you definitely need to be checking this.