### PR TITLE
fix ssl_options and misaligned adressinfo

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -535,6 +535,8 @@ do { \
     do_hook(H_DISCONNECT, "%% Connection to %s closed: %s: %s", "%s %s: %s", \
 	where, what, why)
 
+#define ROUND_UP_LENGTH(len)	((len + 7) & -8)
+
 #if HAVE_SSL
 static void ssl_err(const char *str)
 {
@@ -604,8 +606,8 @@ typedef struct {
     int verify_depth;
     int always_continue;
 } ssl_options_t;
-ssl_options_t ssl_options;
-int ssl_mydata_index;
+static ssl_options_t ssl_options;
+static int ssl_mydata_index;
 
 static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 {
@@ -1409,7 +1411,6 @@ static int opensock(World *world, int flags)
 	SSL_CTX_set_verify_depth(ssl_ctx, ssl_depth);
 	ssl_mydata_index = SSL_get_ex_new_index(0, "ssl_mydata index", 
 		NULL, NULL, NULL);
-	ssl_options_t ssl_options;
 	ssl_options.verify_depth = ssl_depth;
 	ssl_options.verbose_mode = ssl_verbose;
 	ssl_options.always_continue = ssl_continue;
@@ -1628,8 +1629,8 @@ static int openconn(Sock *sock)
 	for (ai = xsock->addrs; ai; ai = ai->ai_next) {
 	    ai->ai_addr = (struct sockaddr*)((char*)ai + sizeof(*ai));
 	    if (ai->ai_next != 0) {
-		ai->ai_next =
-		    (struct addrinfo*)((char*)ai->ai_addr + ai->ai_addrlen);
+		ai->ai_next = 
+		    (struct addrinfo*)((char*)ai->ai_addr + ROUND_UP_LENGTH(ai->ai_addrlen));
 	    }
 	}
 	xsock->addr = xsock->addrs;
@@ -1933,13 +1934,21 @@ static void waitforhostname(int fd, const char *name, const char *port)
 	iov[0].iov_len = sizeof(hdr);
 	niov = 1;
 	for (ai = res; ai && niov < NIOV; ai = ai->ai_next) {
-	    hdr.size += sizeof(*ai) + ai->ai_addrlen;
+	    static const char zeros[ 8 ] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+	    size_t padded = ROUND_UP_LENGTH(ai->ai_addrlen);
+	    hdr.size += sizeof(*ai) + padded;
 	    iov[niov].iov_base = (char*)ai;
 	    iov[niov].iov_len = sizeof(*ai);
 	    niov++;
 	    iov[niov].iov_base = (char*)ai->ai_addr;
 	    iov[niov].iov_len = ai->ai_addrlen;
 	    niov++;
+	    if (padded != ai->ai_addrlen) {
+		/* padding */
+		iov[niov].iov_base = (char*)zeros;
+		iov[niov].iov_len = padded - ai->ai_addrlen;
+		niov++;
+	    }
 	}
 	writev(fd, iov, niov);
 	if (res) freeaddrinfo(res);


### PR DESCRIPTION

Fixes #24

ssl_options is configured on stack.
in the callback the location is overwritten.

Output:
<pre>
% Trying to connect to ap: XXXX:XXXX::42 8889.
% SSL: cert verify depth exceeded: allowed=0 actual=2
% SSL: cert verify error: err=22 'certificate chain too long' depth:2 cn:/C=US/O=Internet
    Security Research Group/CN=ISRG Root X1
% Intermediate connection to ap failed: SSL/lib: error:1416F086:SSL
    routines:tls_process_server_certificate:certificate verify failed
</pre>

Diagnostics:
<pre>
ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fffffffe364 at pc 0x00000041b231 bp 0x7fffffffdb70 sp 0x7fffffffdb68
READ of size 4 at 0x7fffffffe364 thread T0
[Detaching after fork from child process 31672]
    #0 0x41b230  (/usr/local/tmp/usr/ports/current/tinyfugue-devel/work/tinyfugue-5.1.1/src/tf+0x41b230)
    #1 0x8008fd5ce  (/usr/local/lib/libcrypto.so.11+0x2a95ce)
    #2 0x8008fbe9b  (/usr/local/lib/libcrypto.so.11+0x2a7e9b)
    #3 0x8008fac4c in X509_verify_cert (/usr/local/lib/libcrypto.so.11+0x2a6c4c)
    #4 0x80060865e  (/usr/local/lib/libssl.so.11+0x4b65e)
    #5 0x80062b5b8  (/usr/local/lib/libssl.so.11+0x6e5b8)
    #6 0x800627136  (/usr/local/lib/libssl.so.11+0x6a136)
    #7 0x3f6a0c  (/usr/local/tmp/usr/ports/current/tinyfugue-devel/work/tinyfugue-5.1.1/src/tf+0x3f6a0c)
    #8 0x3fb118  (/usr/local/tmp/usr/ports/current/tinyfugue-devel/work/tinyfugue-5.1.1/src/tf+0x3fb118)
    #9 0x40def5  (/usr/local/tmp/usr/ports/current/tinyfugue-devel/work/tinyfugue-5.1.1/src/tf+0x40def5)
    #10 0x39f05c  (/usr/local/tmp/usr/ports/current/tinyfugue-devel/work/tinyfugue-5.1.1/src/tf+0x39f05c)
    #11 0x27344f  (/usr/local/tmp/usr/ports/current/tinyfugue-devel/work/tinyfugue-5.1.1/src/tf+0x27344f)

Address 0x7fffffffe364 is located in stack of thread T0 at offset 164 in frame
    #0 0x4093af  (/usr/local/tmp/usr/ports/current/tinyfugue-devel/work/tinyfugue-5.1.1/src/tf+0x4093af)

  This frame has 7 object(s):
    [32, 40) 'fds.i.i'
    [64, 112) 'hints.i'
    [144, 148) 'uerr'
    [160, 172) 'ssl_options' <== Memory access at offset 164 is inside this variable
    [192, 240) 'hints'
    [272, 400) 'readable'
    [432, 448) 'tv'
</pre>

on 64 Bit arch the aliment of data after an IPv6 address is broken.

Diagnostics:
<pre>
ocket.c:1629:10: runtime error: member access within misaligned address 0x60d00000724c for type 'struct addrinfo', which requires 8 byte alignment
0x60d00000724c: note: pointer points here
  00 00 00 00 00 00 00 00  02 00 00 00 01 00 00 00  06 00 00 00 10 00 00 00  00 00 00 00 00 00 00 00
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior socket.c:1629:10 in
socket.c:1629:10: runtime error: store to misaligned address 0x60d00000726c for type 'struct sockaddr *', which requires 8 byte alignment
0x60d00000726c: note: pointer points here
  00 00 00 00 90 24 08 00  60 60 00 00 00 00 00 00  00 00 00 00 10 02 22 b9  b9 dc 94 2a 00 00 00 00
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior socket.c:1629:10 in
socket.c:1630:14: runtime error: member access within misaligned address 0x60d00000724c for type 'struct addrinfo', which requires 8 byte alignment
0x60d00000724c: note: pointer points here
  00 00 00 00 00 00 00 00  02 00 00 00 01 00 00 00  06 00 00 00 10 00 00 00  00 00 00 00 00 00 00 00
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior socket.c:1630:14 in
socket.c:1630:14: runtime error: load of misaligned address 0x60d000007274 for type 'struct addrinfo *', which requires 8 byte alignment
0x60d000007274: note: pointer points here
  d0 60 00 00 00 00 00 00  00 00 00 00 10 02 22 b9  b9 dc 94 2a 00 00 00 00  00 00 00 00 00 00 00 00
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior socket.c:1630:14 in
socket.c:1628:39: runtime error: member access within misaligned address 0x60d00000724c for type 'struct addrinfo', which requires 8 byte alignment
</pre>
