### PR TITLE
hwrite: fix mbrtowc OOB access when len < start

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -2841,6 +2841,8 @@ static void hwrite(conString *line, int start, int len, int indent)
 
     cx += len;
 
+    assert(line->data + start + len < line->len);
+
     if (!line->charattrs && hilite && attrs)
         attributes_on(current = attrs);
 
@@ -2860,7 +2862,7 @@ static void hwrite(conString *line, int start, int len, int indent)
             col += tabsize - col % tabsize;
         } else {
 #if WIDECHAR
-	    ret = mbrtowc(NULL, (char *)line->data+i, len - i, &is);
+	    ret = mbrtowc(NULL, (char *)line->data+i, start + len - i, &is);
 	    if (ret >= (size_t) -2) {
 		/* Invalid character. Punt. */
 		bufputc(ctrl ? CTRL(c) : c);


### PR DESCRIPTION
when len < start, hwrite() may pass too large values to mbrtowc() since `len - i` wraps around. this caused a crash on musl libc with a long (384 bytes) line containing utf-8 multibyte characters, and a 110 character wide terminal (hwrite was called with start=110 len=109). probably varies on libc implementation, but musl mbrtowc() was returning a very large value when called like this.

the intention seems to be to pass the rest of the bytes-to-be-printed after `i` to mbrtowc, so `start` needs to be added to the calculation.