### PR TITLE
[lua] use lua_pop() to pop the return arg

### DIFF
--- a/src/lua.c
+++ b/src/lua.c
@@ -240,6 +240,6 @@ handle_calllua_function(int n)
 done:
 	/* Default */
 	free(func);
-	lua_settop(lua_state, 0);
+	lua_pop(lua_state, 1);
 	return v;
 }


### PR DESCRIPTION
This is likely better than overriding the stack top, in case of reentrant calls (eg tf -> lua -> tf macro -> lua, etc.)