### PR TITLE
[macro] Add support for whole line attribute matching.

### DIFF
--- a/lib/tf/tf-help
+++ b/lib/tf/tf-help
@@ -648,6 +648,14 @@ addworld()
           matched by the [1mtrigger[22;0m or to display the default message of a [1mhook[22;0m.  
           Default: normal.  See: [1mattributes[22;0m.  
 
+#/def -A
+#-A
+  -A[ngGLAurBbhC] 
+          Limit matching on whole-line [1mattribute[22;0m(s) (normal, [1mgag[22;0m, nohistory,
+          nolog, noactivity, underline, reverse, bold, bell, [1mhilite[22;0m, Color).
+          This should only be used with a [1mtrigger[22;0m (-t).
+          Default: none.  See: [1mattributes[22;0m.  
+
 #/def -P
 #-P
   -P[<[4mpart[24m>]<[4mattr[24m>[;[<[4mpart[24m>]<[4mattr[24m>]...  

--- a/src/socket.c
+++ b/src/socket.c
@@ -2908,6 +2908,7 @@ static void handle_socket_lines(void)
 
 	} else {
 	    if (borg || hilite || gag) {
+		/* Run the trigger matches against this incoming text line */
 		if (find_and_run_matches(NULL, -1, &incoming_text, xworld(),
 		    TRUE, 0))
 		{


### PR DESCRIPTION
This is primarily for matching on whole line colours. Otherwise i'd have to do tricks with a full line match and then decode_attr and some string manipulation/searching.