### PR TITLE
Fixes for GCC-14. handle_python_function defined with only one argume…

### DIFF
--- a/src/expr.c
+++ b/src/expr.c
@@ -974,7 +974,7 @@ static Value *function_switch(const ExprFunc *func, int n, const char *parent)
 #ifdef TFPYTHON
         case FN_python:
 		{
-			struct Value *rv = handle_python_function( opdstr(n-0) );
+			struct Value *rv = handle_python_function( opdstr(n-0), 0 );
 			if( !rv ) {
 				return shareval(val_zero);
 			} else {

--- a/src/tfpython.c
+++ b/src/tfpython.c
@@ -201,7 +201,7 @@ static struct Value* pyvar_to_tfvar( PyObject *pRc )
 {
 	struct Value *rc;
 	char *cstr;
-	int len; // Py_ssize_t len;
+	long int len; // Py_ssize_t len;
 
 	// can be null if exception was thrown
 	if( !pRc ) {
@@ -466,7 +466,7 @@ struct Value *handle_python_command( String *args, int offset )
 	return pyvar_to_tfvar( pRc );
 }
 
-struct Value *handle_python_function( conString *args )
+struct Value *handle_python_function( conString *args, int offset )
 {
 	PyObject *pRc;
 

--- a/src/tfpython.h
+++ b/src/tfpython.h
@@ -23,7 +23,7 @@
 #include "signals.h"    /* suspend(), shell() */
 #include "variable.h"
 
-struct Value *handle_python_function( conString *args );
+struct Value *handle_python_function( conString *args, int offset );
 struct Value *handle_python_command( String *args, int offset );
 struct Value *handle_python_kill_command( String *args, int offset );
 struct Value *handle_python_call_command( String *args, int offset );


### PR DESCRIPTION
resolves ingwarsw/tinyfugue#87

Small fixes for GCC-14. Fixes compiled without issue in debian-sid (gcc14, python3.12.6).

Changed type of len from int to long int for pyvar_to_tfvar in tfpython.c, was generating an error.

expr.c call to handle_python_function had error when compiling Python support.

typedef struct Value in command.h has two arguments. Only one provided in expr.c / tfpython.c/h. Updated tfpython.c/h, and added a default/dummy value in call from expr.c.

There's almost definitely a better way to do this, but I don't really know C at all, and this fixed the errors when compiling with the following options:

--enable-atcp --enable-gmcp --enable-option102 --enable-python