### PR TITLE
PCRE2, GCC15, Python-3.13 updates

### DIFF
--- a/configure
+++ b/configure
@@ -5335,8 +5335,8 @@ esac
 fi
 
 
-# Extract the first word of "pcre-config", so it can be a program name with args.
-set dummy pcre-config; ac_word=$2
+# Extract the first word of "pcre2-config", so it can be a program name with args.
+set dummy pcre2-config; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 printf %s "checking for $ac_word... " >&6; }
 if test ${ac_cv_path_PCRE_CONFIG+y}
@@ -5384,9 +5384,9 @@ fi
 
 if test "$PCRE_CONFIG" != "false"; then
   PCRE_CFLAGS=`$PCRE_CONFIG --cflags`
-  PCRE_LIBS=`$PCRE_CONFIG --libs`
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: using pcre-config to find extra flags" >&5
-printf "%s\n" "$as_me: using pcre-config to find extra flags" >&6;}
+  PCRE_LIBS=`$PCRE_CONFIG --libs8`
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: using pcre2-config to find extra flags" >&5
+printf "%s\n" "$as_me: using pcre2-config to find extra flags" >&6;}
   CFLAGS="${CFLAGS} ${PCRE_CFLAGS}"
   LIBS="${LIBS} ${PCRE_LIBS}"
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}:    ... CFLAGS: ${CFLAGS}" >&5
@@ -5394,9 +5394,9 @@ printf "%s\n" "$as_me:    ... CFLAGS: ${CFLAGS}" >&6;}
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}:    ... LIBS: ${LIBS}" >&5
 printf "%s\n" "$as_me:    ... LIBS: ${LIBS}" >&6;}
 else
-         for ac_header in pcre.h
+         for ac_header in pcre2.h
 do :
-  ac_fn_c_check_header_compile "$LINENO" "pcre.h" "ac_cv_header_pcre_h" "$ac_includes_default"
+  ac_fn_c_check_header_compile "$LINENO" "pcre2.h" "ac_cv_header_pcre_h" "$ac_includes_default"
 if test "x$ac_cv_header_pcre_h" = xyes
 then :
   printf "%s\n" "#define HAVE_PCRE_H 1" >>confdefs.h

--- a/configure.ac
+++ b/configure.ac
@@ -417,18 +417,18 @@ fi
 
 AC_CHECK_LIB(z, inflate, [], [AC_MSG_FAILURE([Cant find inflate in libz])])
 
-AC_PATH_PROG([PCRE_CONFIG], [pcre-config], [false])
+AC_PATH_PROG([PCRE_CONFIG], [pcre2-config], [false])
 if test "$PCRE_CONFIG" != "false"; then
   PCRE_CFLAGS=`$PCRE_CONFIG --cflags`
   PCRE_LIBS=`$PCRE_CONFIG --libs`
-  AC_MSG_NOTICE([using pcre-config to find extra flags])
+  AC_MSG_NOTICE([using pcre2-config to find extra flags])
   CFLAGS="${CFLAGS} ${PCRE_CFLAGS}"
   LIBS="${LIBS} ${PCRE_LIBS}"
   AC_MSG_NOTICE([   ... CFLAGS: ${CFLAGS}])
   AC_MSG_NOTICE([   ... LIBS: ${LIBS}])
 else
-  AC_CHECK_HEADERS([pcre.h], WITH_PCRE=yes, WITH_PCRE=no)
-  AC_CHECK_LIB(pcre, pcre_compile, [], [AC_MSG_FAILURE([Can't find pcre])])
+  AC_CHECK_HEADERS([pcre2.h], WITH_PCRE=yes, WITH_PCRE=no)
+  AC_CHECK_LIB(pcre2-8, pcre2_compile_8, [], [AC_MSG_FAILURE([Can't find pcre])])
 fi
 
 dnl ########### headers ############

--- a/configure.ac
+++ b/configure.ac
@@ -420,7 +420,7 @@ AC_CHECK_LIB(z, inflate, [], [AC_MSG_FAILURE([Cant find inflate in libz])])
 AC_PATH_PROG([PCRE_CONFIG], [pcre2-config], [false])
 if test "$PCRE_CONFIG" != "false"; then
   PCRE_CFLAGS=`$PCRE_CONFIG --cflags`
-  PCRE_LIBS=`$PCRE_CONFIG --libs`
+  PCRE_LIBS=`$PCRE_CONFIG --libs8`
   AC_MSG_NOTICE([using pcre2-config to find extra flags])
   CFLAGS="${CFLAGS} ${PCRE_CFLAGS}"
   LIBS="${LIBS} ${PCRE_LIBS}"

--- a/htmldoc/topics/patterns.html
+++ b/htmldoc/topics/patterns.html
@@ -116,8 +116,8 @@
 <h2>Regular expressions ("regexp")</h2>
 
 <p>
-  TF implements regular expressions with the package PCRE 2.08,
-  Copyright (c) 1997-1999 University of Cambridge.
+  TF implements regular expressions with the package PCRE2,
+  Copyright (c) 1997-2025 University of Cambridge.
   The PCRE regexp syntax is documented on its own page under the topic
   "<a href="../topics/pcre.html">pcre</a>".
 <p>

--- a/htmldoc/topics/pcre.html
+++ b/htmldoc/topics/pcre.html
@@ -1,20 +1,32 @@
 <title>PCRE syntax</title>
 <!--"@pcre"-->
 <!--"@pcre syntax"-->
-This document was extracted from the pcre.3.html documentation,
-Copyright (c) 1997-1999 University of Cambridge,
+This document was extracted from the pcre2.3.html documentation,
+Copyright (c) 1997-2025 University of Cambridge,
 and minimally adapted for use in TinyFugue.
 
+The latest reference can be found at:
+https://www.pcre.org/current/doc/html/index.html
+
 <UL>
-<LI><A NAME="SEC13" HREF="#TOC1">REGULAR EXPRESSION DETAILS</A>
+<li><a name="SEC1" href="#TOC1">PCRE2 REGULAR EXPRESSION DETAILS</a>
 <P>
-The syntax and semantics of the regular expressions supported by PCRE are
-described below. Regular expressions are also described in the Perl
-documentation and in a number of other books, some of which have copious
-examples. Jeffrey Friedl's "Mastering Regular Expressions", published by
-O'Reilly (ISBN 1-56592-257-3), covers them in great detail. The description
-here is intended as reference documentation.
+The syntax and semantics of the regular expressions that are supported by PCRE2
+are described in detail below. PCRE2 tries to match Perl syntax and semantics as closely as it can.
+PCRE2 also supports some alternative regular expression syntax that does not
+conflict with the Perl syntax in order to provide some compatibility with
+regular expressions in Python, .NET, and Oniguruma. There are in addition some
+options that enable alternative syntax and semantics that are not the same as
+in Perl.
 </P>
+<P>
+Perl's regular expressions are described in its own documentation, and regular
+expressions in general are covered in a number of books, some of which have
+copious examples. Jeffrey Friedl's "Mastering Regular Expressions", published
+by O'Reilly, covers regular expressions in great detail. This description of
+PCRE2's regular expressions is intended as reference material.
+</P>
+<li><a name="SEC4" href="#TOC1">CHARACTERS AND METACHARACTERS</a>
 <P>
 A regular expression is a pattern that is matched against a subject string from
 left to right. Most characters stand for themselves in a pattern, and match the
@@ -55,6 +67,9 @@ as follows:
   +      1 or more quantifier
   {      start min/max quantifier
 </PRE>
+Brace characters { and } are also used to enclose data for constructions such
+as \g{2} or \k{name}. In almost all uses of braces, space and/or horizontal
+tab characters that follow { or precede } are allowed and are ignored.
 </P>
 <P>
 Part of a pattern that is in square brackets is called a "character class". In
@@ -71,7 +86,7 @@ a character class the only meta-characters are:
 <P>
 The following sections describe the use of each of the meta-characters.
 </P>
-<LI><A NAME="SEC14" HREF="#TOC1">BACKSLASH</A>
+<LI><A NAME="SEC5" HREF="#TOC1">BACKSLASH</A>
 <P>
 The backslash character has several uses. Firstly, if it is followed by a
 non-alphameric character, it takes away any special meaning that character may
@@ -86,11 +101,38 @@ non-alphameric with "\" to specify that it stands for itself. In particular,
 if you want to match a backslash, you write "\\".
 </P>
 <P>
-If a pattern is compiled with the "x" (PCRE_EXTRA) option, whitespace in the
-pattern (other than in a character class) and characters between a "#" outside
-a character class and the next newline character are ignored. An escaping
-backslash can be used to include a whitespace or "#" character as part of the
-pattern.
+If you want to treat all characters in a sequence as literals, you can do so by
+putting them between \Q and \E. Note that this includes white space even when
+the PCRE2_EXTENDED option is set so that most other white space is ignored. The
+behaviour is different from Perl in that $ and @ are handled as literals in
+\Q...\E sequences in PCRE2, whereas in Perl, $ and @ cause variable
+interpolation. Also, Perl does "double-quotish backslash interpolation" on any
+backslashes between \Q and \E which, its documentation says, "may lead to
+confusing results". PCRE2 treats a backslash between \Q and \E just like any
+other character. Note the following examples:
+<pre>
+  Pattern            PCRE2 matches   Perl matches
+
+  \Qabc$xyz\E        abc$xyz        abc followed by the contents of $xyz
+  \Qabc\$xyz\E       abc\$xyz       abc\$xyz
+  \Qabc\E\$\Qxyz\E   abc$xyz        abc$xyz
+  \QA\B\E            A\B            A\B
+  \Q\\E              \              \\E
+</pre>
+The \Q...\E sequence is recognized both inside and outside character classes.
+An isolated \E that is not preceded by \Q is ignored. If \Q is not followed
+by \E later in the pattern, the literal interpretation continues to the end of
+the pattern (that is, \E is assumed at the end). If the isolated \Q is inside
+a character class, this causes an error, because the character class is then
+not terminated by a closing square bracket.
+</P>
+<P>
+Another difference from Perl is that any appearance of \Q or \E inside what
+might otherwise be a quantifier causes PCRE2 not to recognize the sequence as a
+quantifier. Perl recognizes a quantifier if (redundantly) either of the numbers
+is inside \Q...\E, but not if the separating comma is. When not recognized as
+a quantifier a sequence such as {\Q1\E,2} is treated as the literal string
+"{1,2}".
 </P>
 <P>
 A second use of backslash provides a way of encoding non-printing characters
@@ -102,15 +144,18 @@ represents:
 </P>
 <P>
 <PRE>
-  \a     alarm, that is, the BEL character (hex 07)
-  \cx    "control-x", where x is any character
-  \e     escape (hex 1B)
-  \f     formfeed (hex 0C)
-  \n     newline (hex 0A)
-  \r     carriage return (hex 0D)
-  \t     tab (hex 09)
-  \xhh   character with hex code hh
-  \ddd   character with octal code ddd, or backreference
+  \a          alarm, that is, the BEL character (hex 07)
+  \cx         "control-x", where x is a non-control ASCII character
+  \e          escape (hex 1B)
+  \f          form feed (hex 0C)
+  \n          linefeed (hex 0A)
+  \r          carriage return (hex 0D) (but see below)
+  \t          tab (hex 09)
+  \0dd        character with octal code 0dd
+  \ddd        character with octal code ddd, or back reference
+  \o{ddd..}   character with octal code ddd..
+  \xhh        character with hex code hh
+  \x{hhh..}   character with hex code hhh..
 </PRE>
 </P>
 <P>
@@ -132,7 +177,7 @@ follows is itself an octal digit.
 </P>
 <P>
 The handling of a backslash followed by a digit other than 0 is complicated.
-Outside a character class, PCRE reads it and any following digits as a decimal
+Outside a character class, PCRE2 reads it and any following digits as a decimal
 number. If the number is less than 10, or if there have been at least that many
 previous capturing left parentheses in the expression, the entire sequence is
 taken as a <I>back reference</I>. A description of how this works is given
@@ -179,11 +224,23 @@ The third use of backslash is for specifying generic character types:
 <PRE>
   \d     any decimal digit
   \D     any character that is not a decimal digit
-  \s     any whitespace character
-  \S     any character that is not a whitespace character
+  \h     any horizontal white space character
+  \H     any character that is not a horizontal white space character
+  \N     any character that is not a newline
+  \s     any white space character
+  \S     any character that is not a white space character
+  \v     any vertical white space character
+  \V     any character that is not a vertical white space character
   \w     any "word" character
   \W     any "non-word" character
 </PRE>
+</P>
+<P>
+The \N escape sequence has the same meaning as the "." metacharacter when 
+PCRE2_DOTALL is not set, but setting PCRE2_DOTALL does not change the meaning 
+of \N. Note that when \N is followed by an opening brace it has a different 
+meaning. Perl uses \N{name} to specify characters by Unicode name; 
+PCRE2 does not support this.
 </P>
 <P>
 Each pair of escape sequences partitions the complete set of characters into
@@ -192,7 +249,7 @@ two disjoint sets. Any given character matches one, and only one, of each pair.
 <P>
 A "word" character is any letter or digit or the underscore character, that is,
 any character which can be part of a Perl "word". The definition of letters and
-digits is controlled by PCRE's character tables, and may vary if locale-
+digits is controlled by PCRE2's character tables, and may vary if locale-
 specific matching is taking place (see "Locale support" above). For example, in
 the "fr" (French) locale, some character codes greater than 128 are used for
 accented letters, and these are matched by \w.
@@ -395,38 +452,55 @@ pattern as well as the alternative in the subpattern.
 </P>
 <LI><A NAME="SEC19" HREF="#TOC1">INTERNAL OPTION SETTING</A>
 <P>
-The settings of PCRE_CASELESS, PCRE_EXTENDED, and PCRE_UNGREEDY
-can be changed from within the pattern by a sequence of Perl option letters
-enclosed between "(?" and ")". The option letters are
+The settings of several options can be changed within a pattern by a sequence 
+of letters enclosed between "(?" and ")". The following are Perl-compatible, 
+and are described in detail in the pcre2api documentation. 
+The option letters are:
 </P>
-<P>
 <PRE>
-  i  for PCRE_CASELESS
-  x  for PCRE_EXTENDED
-  U  for PCRE_UNGREEDY (not in perl)
+  i  for PCRE2_CASELESS
+  m  for PCRE2_MULTILINE
+  n  for PCRE2_NO_AUTO_CAPTURE
+  s  for PCRE2_DOTALL
+  x  for PCRE2_EXTENDED
+  xx for PCRE2_EXTENDED_MORE
 </PRE>
+<P>
+For example, (?im) sets caseless, multiline matching. It is also possible to 
+unset these options by preceding the relevant letters with a hyphen, for 
+example (?-im). The two "extended" options are not independent; unsetting 
+either one cancels the effects of both of them.
 </P>
 <P>
-For example, (?x) sets extended matching. It is also possible to
-unset these options by preceding the letter with a hyphen, and a combined
-setting and unsetting such as (?x-i), which sets extended and
-while unsetting caseless, is also
-permitted. If a letter appears both before and after the hyphen, the option is
-unset.
+A combined setting and unsetting such as (?im-sx), which sets PCRE2_CASELESS 
+and PCRE2_MULTILINE while unsetting PCRE2_DOTALL and PCRE2_EXTENDED, is also 
+permitted. Only one hyphen may appear in the options string. If a letter 
+appears both before and after the hyphen, the option is unset. An empty options
+setting "(?)" is allowed. Needless to say, it has no effect.
 </P>
 <P>
-The scope of these option changes depends on where in the pattern the setting
-occurs. For settings that are outside any subpattern (defined below), the
-effect is the same as if the options were set or unset at the start of
-matching. The following patterns all behave in exactly the same way:
+If the first character following (? is a circumflex, it causes all of the 
+above options to be unset. Letters may follow the circumflex to cause some 
+options to be re-instated, but a hyphen may not appear.
 </P>
 <P>
+Some PCRE2-specific options can be changed by the same mechanism using these 
+pairs or individual letters:
+</P>
 <PRE>
-  (?i)ABC
-  A(?i)BC
-  AB(?i)C
-  ABC(?i)
+  aD for PCRE2_EXTRA_ASCII_BSD
+  aS for PCRE2_EXTRA_ASCII_BSS
+  aW for PCRE2_EXTRA_ASCII_BSW
+  aP for PCRE2_EXTRA_ASCII_POSIX and PCRE2_EXTRA_ASCII_DIGIT
+  aT for PCRE2_EXTRA_ASCII_DIGIT
+  r  for PCRE2_EXTRA_CASELESS_RESTRICT
+  J  for PCRE2_DUPNAMES
+  U  for PCRE2_UNGREEDY
 </PRE>
+<P>
+However, except for 'r', these are not unset by (?^), which is equivalent to 
+(?-imnrsx). If 'a' is not followed by any of the upper case letters shown 
+above, it sets (or unsets) all the ASCII options.
 </P>
 <P>
 Such "top level" settings apply to the whole pattern (unless
@@ -434,9 +508,9 @@ there are other changes inside subpatterns). If there is more than one setting
 of the same option at top level, the rightmost setting is used.
 </P>
 <P>
-If an option change occurs inside a subpattern, the effect is different. This
-is a change of behaviour in Perl 5.005. An option change inside a subpattern
-affects only that part of the subpattern that follows it, so
+If an option change occurs inside a subpattern, the effect is different. 
+An option change inside a subpattern affects only that part of the 
+subpattern that follows it, so
 </P>
 
 <P>
@@ -472,634 +546,713 @@ earlier in the pattern than any of the additional features it turns on, even
 when it is at top level. It is best put at the start.
 </P>
 -->
-<LI><A NAME="SEC20" HREF="#TOC1">SUBPATTERNS</A>
+<LI><a name="SEC16" href="#TOC1">GROUPS</a><br>
 <P>
-Subpatterns are delimited by parentheses (round brackets), which can be nested.
-Marking part of a pattern as a subpattern does two things:
-</P>
-<P>
+Groups are delimited by parentheses (round brackets), which can be nested.
+Turning part of a pattern into a group does two things:
+<br>
+<br>
 1. It localizes a set of alternatives. For example, the pattern
-</P>
-<P>
-<PRE>
+<pre>
   cat(aract|erpillar|)
-</PRE>
+</pre>
+matches "cataract", "caterpillar", or "cat". Without the parentheses, it would
+match "cataract", "erpillar" or an empty string.
+<br>
+<br>
+2. It creates a "capture group". This means that, when the whole pattern
+matches, the portion of the subject string that matched the group is passed
+back to the caller, separately from the portion that matched the whole pattern.
+(This applies only to the traditional matching function; the DFA matching
+function does not support capturing.)
 </P>
 <P>
-matches one of the words "cat", "cataract", or "caterpillar". Without the
-parentheses, it would match "cataract", "erpillar" or the empty string.
-</P>
-<P>
-2. It sets up the subpattern as a capturing subpattern (as defined above).
-When the whole pattern matches, that portion of the subject string that matched
-the subpattern is remembered for the TinyFugue %Pn substitutions.
-Opening parentheses are counted from left to right (starting
-from 1) to obtain the numbers of the capturing subpatterns.
-</P>
-<P>
-For example, if the string "the red king" is matched against the pattern
-</P>
-<P>
-<PRE>
+Opening parentheses are counted from left to right (starting from 1) to obtain
+numbers for capture groups. For example, if the string "the red king" is
+matched against the pattern
+<pre>
   the ((red|white) (king|queen))
-</PRE>
-</P>
-<P>
+</pre>
 the captured substrings are "red king", "red", and "king", and are numbered 1,
-2, and 3.
+2, and 3, respectively.
 </P>
 <P>
 The fact that plain parentheses fulfil two functions is not always helpful.
-There are often times when a grouping subpattern is required without a
-capturing requirement. If an opening parenthesis is followed by "?:", the
-subpattern does not do any capturing, and is not counted when computing the
-number of any subsequent capturing subpatterns. For example, if the string "the
-white queen" is matched against the pattern
-</P>
-<P>
-<PRE>
+There are often times when grouping is required without capturing. If an
+opening parenthesis is followed by a question mark and a colon, the group
+does not do any capturing, and is not counted when computing the number of any
+subsequent capture groups. For example, if the string "the white queen"
+is matched against the pattern
+<pre>
   the ((?:red|white) (king|queen))
-</PRE>
-</P>
-<P>
+</pre>
 the captured substrings are "white queen" and "queen", and are numbered 1 and
-2. The maximum number of captured substrings is 99, and the maximum number of
-all subpatterns, both capturing and non-capturing, is 200.
+2. The maximum number of capture groups is 65535.
 </P>
 <P>
 As a convenient shorthand, if any option settings are required at the start of
-a non-capturing subpattern, the option letters may appear between the "?" and
-the ":". Thus the two patterns
-</P>
-<P>
-<PRE>
+a non-capturing group, the option letters may appear between the "?" and the
+":". Thus the two patterns
+<pre>
   (?i:saturday|sunday)
   (?:(?i)saturday|sunday)
-</PRE>
-</P>
-<P>
+</pre>
 match exactly the same set of strings. Because alternative branches are tried
-from left to right, and options are not reset until the end of the subpattern
-is reached, an option setting in one branch does affect subsequent branches, so
+from left to right, and options are not reset until the end of the group is
+reached, an option setting in one branch does affect subsequent branches, so
 the above patterns match "SUNDAY" as well as "Saturday".
-</P>
-<LI><A NAME="SEC21" HREF="#TOC1">REPETITION</A>
+<a name="dupgroupnumber"></a></P>
+<br><a name="SEC17" href="#TOC1">DUPLICATE GROUP NUMBERS</a><br>
 <P>
-Repetition is specified by quantifiers, which can follow any of the following
+Perl 5.10 introduced a feature whereby each alternative in a group uses the
+same numbers for its capturing parentheses. Such a group starts with (?| and is
+itself a non-capturing group. For example, consider this pattern:
+<pre>
+  (?|(Sat)ur|(Sun))day
+</pre>
+Because the two alternatives are inside a (?| group, both sets of capturing
+parentheses are numbered one. Thus, when the pattern matches, you can look
+at captured substring number one, whichever alternative matched. This construct
+is useful when you want to capture part, but not all, of one of a number of
+alternatives. Inside a (?| group, parentheses are numbered as usual, but the
+number is reset at the start of each branch. The numbers of any capturing
+parentheses that follow the whole group start after the highest number used in
+any branch. The following example is taken from the Perl documentation. The
+numbers underneath show in which buffer the captured content will be stored.
+<pre>
+  # before  ---------------branch-reset----------- after
+  / ( a )  (?| x ( y ) z | (p (q) r) | (t) u (v) ) ( z ) /x
+  # 1            2         2  3        2     3     4
+</pre>
+A backreference to a capture group uses the most recent value that is set for
+the group. The following pattern matches "abcabc" or "defdef":
+<pre>
+  /(?|(abc)|(def))\1/
+</pre>
+In contrast, a subroutine call to a capture group always refers to the
+first one in the pattern with the given number. The following pattern matches
+"abcabc" or "defabc":
+<pre>
+  /(?|(abc)|(def))(?1)/
+</pre>
+A relative reference such as (?-1) is no different: it is just a convenient way
+of computing an absolute group number.
+</P>
+<P>
+If a condition test
+for a group's having matched refers to a non-unique number, the test is
+true if any group with that number has matched.
+</P>
+<LI><a name="SEC19" href="#TOC1">REPETITION</a><br>
+<P>
+Repetition is specified by quantifiers, which may follow any one of these
 items:
-</P>
-<P>
-<PRE>
-  a single character, possibly escaped
-  the . metacharacter
+<pre>
+  a literal data character
+  the dot metacharacter
+  the \C escape sequence
+  the \R escape sequence
+  the \X escape sequence
+  any escape sequence that matches a single character
   a character class
-  a back reference (see next section)
-  a parenthesized subpattern (unless it is an assertion - see below)
-</PRE>
-</P>
-<P>
-The general repetition quantifier specifies a minimum and maximum number of
-permitted matches, by giving the two numbers in curly brackets (braces),
-separated by a comma. The numbers must be less than 65536, and the first must
-be less than or equal to the second. For example:
-</P>
-<P>
-<PRE>
+  a backreference
+  a parenthesized group (including lookaround assertions)
+  a subroutine call (recursive or otherwise)
+</pre>
+If a quantifier does not follow a repeatable item, an error occurs. The
+general repetition quantifier specifies a minimum and maximum number of
+permitted matches by giving two numbers in curly brackets (braces), separated
+by a comma. The numbers must be less than 65536, and the first must be less
+than or equal to the second. For example,
+<pre>
   z{2,4}
-</PRE>
-</P>
-<P>
+</pre>
 matches "zz", "zzz", or "zzzz". A closing brace on its own is not a special
 character. If the second number is omitted, but the comma is present, there is
 no upper limit; if the second number and the comma are both omitted, the
 quantifier specifies an exact number of required matches. Thus
-</P>
-<P>
-<PRE>
+<pre>
   [aeiou]{3,}
-</PRE>
-</P>
-<P>
-matches at least 3 successive vowels, but may match many more, while
-</P>
-<P>
-<PRE>
+</pre>
+matches at least 3 successive vowels, but may match many more, whereas
+<pre>
   \d{8}
-</PRE>
+</pre>
+matches exactly 8 digits. If the first number is omitted, the lower limit is
+taken as zero; in this case the upper limit must be present.
+<pre>
+  X{,4} is interpreted as X{0,4}
+</pre>
+This is a change in behaviour that happened in Perl 5.34.0 and PCRE2 10.43. In
+earlier versions such a sequence was not interpreted as a quantifier. Other
+regular expression engines may behave either way.
 </P>
 <P>
-matches exactly 8 digits. An opening curly bracket that appears in a position
-where a quantifier is not allowed, or one that does not match the syntax of a
-quantifier, is taken as a literal character. For example, {,6} is not a
-quantifier, but a literal string of four characters.
+If the characters that follow an opening brace do not match the syntax of a
+quantifier, the brace is taken as a literal character. In particular, this
+means that {,} is a literal string of three characters.
+</P>
+<P>
+Note that not every opening brace is potentially the start of a quantifier
+because braces are used in other items such as \N{U+345} or \k{name}.
 </P>
 <P>
 The quantifier {0} is permitted, causing the expression to behave as if the
-previous item and the quantifier were not present.
+previous item and the quantifier were not present. This may be useful for
+capture groups that are referenced as
+<a href="#groupsassubroutines">subroutines</a>
+from elsewhere in the pattern (but see also the section entitled
+<a href="#subdefine">"Defining capture groups for use by reference only"</a>
+below). Except for parenthesized groups, items that have a {0} quantifier are
+omitted from the compiled pattern.
 </P>
 <P>
-For convenience (and historical compatibility) the three most common
-quantifiers have single-character abbreviations:
-</P>
-<P>
-<PRE>
+For convenience, the three most common quantifiers have single-character
+abbreviations:
+<pre>
   *    is equivalent to {0,}
   +    is equivalent to {1,}
   ?    is equivalent to {0,1}
-</PRE>
-</P>
-<P>
-It is possible to construct infinite loops by following a subpattern that can
-match no characters with a quantifier that has no upper limit, for example:
-</P>
-<P>
-<PRE>
+</pre>
+It is possible to construct infinite loops by following a group that can match
+no characters with a quantifier that has no upper limit, for example:
+<pre>
   (a?)*
-</PRE>
-</P>
-<P>
-Earlier versions of Perl and PCRE used to give an error at compile time for
+</pre>
+Earlier versions of Perl and PCRE1 used to give an error at compile time for
 such patterns. However, because there are cases where this can be useful, such
-patterns are now accepted, but if any repetition of the subpattern does in fact
-match no characters, the loop is forcibly broken.
+patterns are now accepted, but whenever an iteration of such a group matches no
+characters, matching moves on to the next item in the pattern instead of
+repeatedly matching an empty string. This does not prevent backtracking into
+any of the iterations if a subsequent item fails to match.
 </P>
 <P>
-By default, the quantifiers are "greedy", that is, they match as much as
-possible (up to the maximum number of permitted times), without causing the
-rest of the pattern to fail. The classic example of where this gives problems
-is in trying to match comments in C programs. These appear between the
-sequences /* and */ and within the sequence, individual * and / characters may
-appear. An attempt to match C comments by applying the pattern
-</P>
-<P>
-<PRE>
+By default, quantifiers are "greedy", that is, they match as much as possible
+(up to the maximum number of permitted repetitions), without causing the rest
+of the pattern to fail. The classic example of where this gives problems is in
+trying to match comments in C programs. These appear between /* and */ and
+within the comment, individual * and / characters may appear. An attempt to
+match C comments by applying the pattern
+<pre>
   /\*.*\*/
-</PRE>
-</P>
-<P>
+</pre>
 to the string
-</P>
-<P>
-<PRE>
-  /* first command */  not comment  /* second comment */
-</PRE>
-</P>
-<P>
-fails, because it matches the entire string due to the greediness of the .*
-item.
-</P>
-<P>
-However, if a quantifier is followed by a question mark, then it ceases to be
+<pre>
+  /* first comment */  not comment  /* second comment */
+</pre>
+fails, because it matches the entire string owing to the greediness of the .*
+item. However, if a quantifier is followed by a question mark, it ceases to be
 greedy, and instead matches the minimum number of times possible, so the
 pattern
-</P>
-<P>
-<PRE>
+<pre>
   /\*.*?\*/
-</PRE>
-</P>
-<P>
-does the right thing with the C comments. The meaning of the various
-quantifiers is not otherwise changed, just the preferred number of matches.
-Do not confuse this use of question mark with its use as a quantifier in its
-own right. Because it has two uses, it can sometimes appear doubled, as in
-</P>
-<P>
-<PRE>
+</pre>
+does the right thing with C comments. The meaning of the various quantifiers is
+not otherwise changed, just the preferred number of matches. Do not confuse
+this use of question mark with its use as a quantifier in its own right.
+Because it has two uses, it can sometimes appear doubled, as in
+<pre>
   \d??\d
-</PRE>
-</P>
-<P>
+</pre>
 which matches one digit by preference, but can match two if that is the only
 way the rest of the pattern matches.
 </P>
 <P>
-If the "U" (PCRE_UNGREEDY) option is set (an option which is not available in Perl)
-then the quantifiers are not greedy by default, but individual ones can be made
+If the PCRE2_UNGREEDY option is set (an option that is not available in Perl),
+the quantifiers are not greedy by default, but individual ones can be made
 greedy by following them with a question mark. In other words, it inverts the
 default behaviour.
 </P>
 <P>
-When a parenthesized subpattern is quantified with a minimum repeat count that
-is greater than 1 or with a limited maximum, more store is required for the
+When a parenthesized group is quantified with a minimum repeat count that
+is greater than 1 or with a limited maximum, more memory is required for the
 compiled pattern, in proportion to the size of the minimum or maximum.
 </P>
 <P>
-If a pattern starts with .* or .{0,}<!-- and the PCRE_DOTALL option (equivalent
-to Perl's /s) is set, thus allowing the . to match newlines-->, then the pattern
-is implicitly anchored, because whatever follows will be tried against every
+If a pattern starts with .* or .{0,} and the PCRE2_DOTALL option (equivalent
+to Perl's /s) is set, thus allowing the dot to match newlines, the pattern is
+implicitly anchored, because whatever follows will be tried against every
 character position in the subject string, so there is no point in retrying the
-overall match at any position after the first. PCRE treats such a pattern as
-though it were preceded by \A.
-<!-- In cases where it is known that the subject
-string contains no newlines, it is worth setting PCRE_DOTALL when the pattern
-begins with .* in order to obtain this optimization, or alternatively using ^
-to indicate anchoring explicitly. -->
+overall match at any position after the first. PCRE2 normally treats such a
+pattern as though it were preceded by \A.
 </P>
 <P>
-When a capturing subpattern is repeated, the value captured is the substring
-that matched the final iteration. For example, after
+In cases where it is known that the subject string contains no newlines, it is
+worth setting PCRE2_DOTALL in order to obtain this optimization, or
+alternatively, using ^ to indicate anchoring explicitly.
 </P>
 <P>
-<PRE>
+However, there are some cases where the optimization cannot be used. When .*
+is inside capturing parentheses that are the subject of a backreference
+elsewhere in the pattern, a match at the start may fail where a later one
+succeeds. Consider, for example:
+<pre>
+  (.*)abc\1
+</pre>
+If the subject is "xyz123abc123" the match point is the fourth character. For
+this reason, such a pattern is not implicitly anchored.
+</P>
+<P>
+Another case where implicit anchoring is not applied is when the leading .* is
+inside an atomic group. Once again, a match at the start may fail where a later
+one succeeds. Consider this pattern:
+<pre>
+  (?&#62;.*?a)b
+</pre>
+It matches "ab" in the subject "aab". The use of the backtracking control verbs
+(*PRUNE) and (*SKIP) also disable this optimization. To do so explicitly,
+either pass the compile option PCRE2_NO_DOTSTAR_ANCHOR, or call
+<b>pcre2_set_optimize()</b> with a PCRE2_DOTSTAR_ANCHOR_OFF directive.
+</P>
+<P>
+When a capture group is repeated, the value captured is the substring that
+matched the final iteration. For example, after
+<pre>
   (tweedle[dume]{3}\s*)+
-</PRE>
-</P>
-<P>
+</pre>
 has matched "tweedledum tweedledee" the value of the captured substring is
-"tweedledee". However, if there are nested capturing subpatterns, the
-corresponding captured values may have been set in previous iterations. For
-example, after
-</P>
-<P>
-<PRE>
-  /(a|(b))+/
-</PRE>
-</P>
-<P>
+"tweedledee". However, if there are nested capture groups, the corresponding
+captured values may have been set in previous iterations. For example, after
+<pre>
+  (a|(b))+
+</pre>
 matches "aba" the value of the second captured substring is "b".
-</P>
-<LI><A NAME="SEC22" HREF="#TOC1">BACK REFERENCES</A>
+<LI><a name="SEC22" href="#TOC1">ASSERTIONS</a><br>
 <P>
-Outside a character class, a backslash followed by a digit greater than 0 (and
-possibly further digits) is a back reference to a capturing subpattern earlier
-(i.e. to its left) in the pattern, provided there have been that many previous
-capturing left parentheses.
-</P>
-<P>
-However, if the decimal number following the backslash is less than 10, it is
-always taken as a back reference, and causes an error only if there are not
-that many capturing left parentheses in the entire pattern. In other words, the
-parentheses that are referenced need not be to the left of the reference for
-numbers less than 10. See the section entitled "Backslash" above for further
-details of the handling of digits following a backslash.
+An assertion is a test that does not consume any characters. The test must
+succeed for the match to continue. The simple assertions coded as \b, \B,
+\A, \G, \Z, \z, ^ and $ are described
+<a href="#smallassertions">above.</a>
 </P>
 <P>
-A back reference matches whatever actually matched the capturing subpattern in
-the current subject string, rather than anything matching the subpattern
-itself. So the pattern
+More complicated assertions are coded as parenthesized groups. If matching such
+a group succeeds, matching continues after it, but with the matching position
+in the subject string reset to what it was before the assertion was processed.
 </P>
 <P>
-<PRE>
-  (sens|respons)e and \1ibility
-</PRE>
+A special kind of assertion, called a "scan substring" assertion, matches a
+subpattern against a previously captured substring. This is described in the
+section entitled
+<a href="#scansubstringassertions">"Scan substring assertions"</a>
+below. It is a PCRE2 extension, not compatible with Perl.
 </P>
 <P>
-matches "sense and sensibility" and "response and responsibility", but not
-"sense and responsibility". If caseful matching is in force at the time of the
-back reference, then the case of letters is relevant. For example,
+The other goup-based assertions are of two kinds: those that look ahead of the
+current position in the subject string, and those that look behind it, and in
+each case an assertion may be positive (must match for the assertion to be
+true) or negative (must not match for the assertion to be true).
 </P>
 <P>
-<PRE>
-  ((?i)rah)\s+\1
-</PRE>
+The Perl-compatible lookaround assertions are atomic. If an assertion is true,
+but there is a subsequent matching failure, there is no backtracking into the
+assertion. However, there are some cases where non-atomic assertions can be
+useful. PCRE2 has some support for these, described in the section entitled
+<a href="#nonatomicassertions">"Non-atomic assertions"</a>
+below, but they are not Perl-compatible.
 </P>
 <P>
-matches "rah rah" and "RAH RAH", but not "RAH rah", even though the original
-capturing subpattern is matched caselessly.
+A lookaround assertion may appear as the condition in a
+<a href="#conditions">conditional group</a>
+(see below). In this case, the result of matching the assertion determines
+which branch of the condition is followed.
 </P>
 <P>
-There may be more than one back reference to the same subpattern. If a
-subpattern has not actually been used in a particular match, then any back
-references to it always fail. For example, the pattern
+Assertion groups are not capture groups. If an assertion contains capture
+groups within it, these are counted for the purposes of numbering the capture
+groups in the whole pattern. Within each branch of an assertion, locally
+captured substrings may be referenced in the usual way. For example, a sequence
+such as (.)\g{-1} can be used to check that two adjacent characters are the
+same.
 </P>
 <P>
-<PRE>
-  (a|(bc))\2
-</PRE>
+When a branch within an assertion fails to match, any substrings that were
+captured are discarded (as happens with any pattern branch that fails to
+match). A negative assertion is true only when all its branches fail to match;
+this means that no captured substrings are ever retained after a successful
+negative assertion. When an assertion contains a matching branch, what happens
+depends on the type of assertion.
 </P>
 <P>
-always fails if it starts to match "a" rather than "bc". Because there may be
-up to 99 back references, all digits following the backslash are taken
-as part of a potential back reference number. If the pattern continues with a
-digit character, then some delimiter must be used to terminate the back
-reference. If the "x" (PCRE_EXTENDED) option is set, this can be whitespace.
-Otherwise an empty comment can be used.
+For a positive assertion, internally captured substrings in the successful
+branch are retained, and matching continues with the next pattern item after
+the assertion. For a negative assertion, a matching branch means that the
+assertion is not true. If such an assertion is being used as a condition in a
+<a href="#conditions">conditional group</a>
+(see below), captured substrings are retained, because matching continues with
+the "no" branch of the condition. For other failing negative assertions,
+control passes to the previous backtracking point, thus discarding any captured
+strings within the assertion.
 </P>
 <P>
-A back reference that occurs inside the parentheses to which it refers fails
-when the subpattern is first used, so, for example, (a\1) never matches.
-However, such references can be useful inside repeated subpatterns. For
-example, the pattern
+Most assertion groups may be repeated; though it makes no sense to assert the
+same thing several times, the side effect of capturing in positive assertions
+may occasionally be useful. However, an assertion that forms the condition for
+a conditional group may not be quantified. PCRE2 used to restrict the
+repetition of assertions, but from release 10.35 the only restriction is that
+an unlimited maximum repetition is changed to be one more than the minimum. For
+example, {3,} is treated as {3,4}.
 </P>
+<br><b>
+Alphabetic assertion names
+</b><br>
 <P>
-<PRE>
-  (a|b\1)+
-</PRE>
+Traditionally, symbolic sequences such as (?= and (?&#60;= have been used to
+specify lookaround assertions. Perl 5.28 introduced some experimental
+alphabetic alternatives which might be easier to remember. They all start with
+(* instead of (? and must be written using lower case letters. PCRE2 supports
+the following synonyms:
+<pre>
+  (*positive_lookahead:  or (*pla: is the same as (?=
+  (*negative_lookahead:  or (*nla: is the same as (?!
+  (*positive_lookbehind: or (*plb: is the same as (?&#60;=
+  (*negative_lookbehind: or (*nlb: is the same as (?&#60;!
+</pre>
+For example, (*pla:foo) is the same assertion as (?=foo). In the following
+sections, the various assertions are described using the original symbolic
+forms.
 </P>
+<br><b>
+Lookahead assertions
+</b><br>
 <P>
-matches any number of "a"s and also "aba", "ababaa" etc. At each iteration of
-the subpattern, the back reference matches the character string corresponding
-to the previous iteration. In order for this to work, the pattern must be such
-that the first iteration does not need to match the back reference. This can be
-done using alternation, as in the example above, or by a quantifier with a
-minimum of zero.
-</P>
-<LI><A NAME="SEC23" HREF="#TOC1">ASSERTIONS</A>
-<P>
-An assertion is a test on the characters following or preceding the current
-matching point that does not actually consume any characters. The simple
-assertions coded as \b, \B, \A, \Z, \z, ^ and $ are described above. More
-complicated assertions are coded as subpatterns. There are two kinds: those
-that look ahead of the current position in the subject string, and those that
-look behind it.
-</P>
-<P>
-An assertion subpattern is matched in the normal way, except that it does not
-cause the current matching position to be changed. Lookahead assertions start
-with (?= for positive assertions and (?! for negative assertions. For example,
-</P>
-<P>
-<PRE>
+Lookahead assertions start with (?= for positive assertions and (?! for
+negative assertions. For example,
+<pre>
   \w+(?=;)
-</PRE>
-</P>
-<P>
+</pre>
 matches a word followed by a semicolon, but does not include the semicolon in
 the match, and
-</P>
-<P>
-<PRE>
+<pre>
   foo(?!bar)
-</PRE>
-</P>
-<P>
+</pre>
 matches any occurrence of "foo" that is not followed by "bar". Note that the
 apparently similar pattern
-</P>
-<P>
-<PRE>
+<pre>
   (?!foo)bar
-</PRE>
-</P>
-<P>
+</pre>
 does not find an occurrence of "bar" that is preceded by something other than
 "foo"; it finds any occurrence of "bar" whatsoever, because the assertion
 (?!foo) is always true when the next three characters are "bar". A
-lookbehind assertion is needed to achieve this effect.
+lookbehind assertion is needed to achieve the other effect.
 </P>
+<P>
+If you want to force a matching failure at some point in a pattern, the most
+convenient way to do it is with (?!) because an empty string always matches, so
+an assertion that requires there not to be an empty string must always fail.
+The backtracking control verb (*FAIL) or (*F) is a synonym for (?!).
+<a name="lookbehind"></a></P>
+<br><b>
+Lookbehind assertions
+</b><br>
 <P>
 Lookbehind assertions start with (?&#60;= for positive assertions and (?&#60;! for
 negative assertions. For example,
-</P>
-<P>
-<PRE>
+<pre>
   (?&#60;!foo)bar
-</PRE>
-</P>
-<P>
+</pre>
 does find an occurrence of "bar" that is not preceded by "foo". The contents of
-a lookbehind assertion are restricted such that all the strings it matches must
-have a fixed length. However, if there are several alternatives, they do not
-all have to have the same fixed length. Thus
+a lookbehind assertion are restricted such that there must be a known maximum
+to the lengths of all the strings it matches. There are two cases:
 </P>
 <P>
-<PRE>
-  (?&#60;=bullock|donkey)
+If every top-level alternative matches a fixed length, for example
+<pre>
+  (?&#60;=colour|color)
+</pre>
+there is a limit of 65535 characters to the lengths, which do not have to be
+the same, as this example demonstrates. This is the only kind of lookbehind
+supported by PCRE2 versions earlier than 10.43 and by the alternative matching
+function <b>pcre2_dfa_match()</b>.
+</P>
+<P>
+In PCRE2 10.43 and later, <b>pcre2_match()</b> supports lookbehind assertions in
+which one or more top-level alternatives can match more than one string length,
+for example
+<pre>
+  (?&#60;=colou?r)
+</pre>
+The maximum matching length for any branch of the lookbehind is limited to a
+value set by the calling program (default 255 characters). Unlimited repetition
+(for example \d*) is not supported. In some cases, the escape sequence \K
+<a href="#resetmatchstart">(see above)</a>
+can be used instead of a lookbehind assertion at the start of a pattern to get
+round the length limit restriction.
+</P>
+<P>
+In UTF-8 and UTF-16 modes, PCRE2 does not allow the \C escape (which matches a
+single code unit even in a UTF mode) to appear in lookbehind assertions,
+because it makes it impossible to calculate the length of the lookbehind. The
+\X and \R escapes, which can match different numbers of code units, are never
+permitted in lookbehinds.
+</P>
+<P>
+<a href="#groupsassubroutines">"Subroutine"</a>
+calls such as (?2) or (?&X) are permitted in lookbehinds, as long
+as the called capture group matches a limited-length string. However,
+<a href="#recursion">recursion,</a>
+that is, a "subroutine" call into a group that is already active,
+is not supported.
+</P>
+<P>
+PCRE2 supports backreferences in lookbehinds, but only if certain conditions
+are met. The PCRE2_MATCH_UNSET_BACKREF option must not be set, there must be no
+use of (?| in the pattern (it creates duplicate group numbers), and if the
+backreference is by name, the name must be unique. Of course, the referenced
+group must itself match a limited length substring. The following pattern
+matches words containing at least two characters that begin and end with the
+same character:
+<pre>
+   \b(\w)\w++(?&#60;=\1)
 </PRE>
 </P>
 <P>
-is permitted, but
+Possessive quantifiers can be used in conjunction with lookbehind assertions to
+specify efficient matching at the end of subject strings. Consider a simple
+pattern such as
+<pre>
+  abcd$
+</pre>
+when applied to a long string that does not match. Because matching proceeds
+from left to right, PCRE2 will look for each "a" in the subject and then see if
+what follows matches the rest of the pattern. If the pattern is specified as
+<pre>
+  ^.*abcd$
+</pre>
+the initial .* matches the entire string at first, but when this fails (because
+there is no following "a"), it backtracks to match all but the last character,
+then all but the last two characters, and so on. Once again the search for "a"
+covers the entire string, from right to left, so we are no better off. However,
+if the pattern is written as
+<pre>
+  ^.*+(?&#60;=abcd)
+</pre>
+there can be no backtracking for the .*+ item because of the possessive
+quantifier; it can match only the entire string. The subsequent lookbehind
+assertion does a single test on the last four characters. If it fails, the
+match fails immediately. For long strings, this approach makes a significant
+difference to the processing time.
 </P>
-<P>
-<PRE>
-  (?&#60;!dogs?|cats?)
-</PRE>
-</P>
-<P>
-causes an error at compile time. Branches that match different length strings
-are permitted only at the top level of a lookbehind assertion. This is an
-extension compared with Perl 5.005, which requires all branches to match the
-same length of string. An assertion such as
-</P>
-<P>
-<PRE>
-  (?&#60;=ab(c|de))
-</PRE>
-</P>
-<P>
-is not permitted, because its single top-level branch can match two different
-lengths, but it is acceptable if rewritten to use two top-level branches:
-</P>
-<P>
-<PRE>
-  (?&#60;=abc|abde)
-</PRE>
-</P>
-<P>
-The implementation of lookbehind assertions is, for each alternative, to
-temporarily move the current position back by the fixed width and then try to
-match. If there are insufficient characters before the current position, the
-match is deemed to fail. Lookbehinds in conjunction with once-only subpatterns
-can be particularly useful for matching at the ends of strings; an example is
-given at the end of the section on once-only subpatterns.
-</P>
+<br><b>
+Using multiple assertions
+</b><br>
 <P>
 Several assertions (of any sort) may occur in succession. For example,
-</P>
-<P>
-<PRE>
+<pre>
   (?&#60;=\d{3})(?&#60;!999)foo
-</PRE>
-</P>
-<P>
+</pre>
 matches "foo" preceded by three digits that are not "999". Notice that each of
 the assertions is applied independently at the same point in the subject
 string. First there is a check that the previous three characters are all
-digits, then there is a check that the same three characters are not "999".
-This pattern does <I>not</I> match "foo" preceded by six characters, the first
+digits, and then there is a check that the same three characters are not "999".
+This pattern does <i>not</i> match "foo" preceded by six characters, the first
 of which are digits and the last three of which are not "999". For example, it
 doesn't match "123abcfoo". A pattern to do that is
-</P>
-<P>
-<PRE>
+<pre>
   (?&#60;=\d{3}...)(?&#60;!999)foo
-</PRE>
-</P>
-<P>
+</pre>
 This time the first assertion looks at the preceding six characters, checking
 that the first three are digits, and then the second assertion checks that the
 preceding three characters are not "999".
 </P>
 <P>
 Assertions can be nested in any combination. For example,
-</P>
-<P>
-<PRE>
+<pre>
   (?&#60;=(?&#60;!foo)bar)baz
-</PRE>
-</P>
-<P>
+</pre>
 matches an occurrence of "baz" that is preceded by "bar" which in turn is not
 preceded by "foo", while
-</P>
-<P>
-<PRE>
+<pre>
   (?&#60;=\d{3}(?!999)...)foo
-</PRE>
-</P>
-<P>
-is another pattern which matches "foo" preceded by three digits and any three
+</pre>
+is another pattern that matches "foo" preceded by three digits and any three
 characters that are not "999".
-</P>
+<LI><a name="SEC26" href="#TOC1">CONDITIONAL GROUPS</a><br>
 <P>
-Assertion subpatterns are not capturing subpatterns, and may not be repeated,
-because it makes no sense to assert the same thing several times. If any kind
-of assertion contains capturing subpatterns within it, these are counted for
-the purposes of numbering the capturing subpatterns in the whole pattern.
-However, substring capturing is carried out only for positive assertions,
-because it does not make sense for negative assertions.
-</P>
-<P>
-Assertions count towards the maximum of 200 parenthesized subpatterns.
-</P>
-<LI><A NAME="SEC24" HREF="#TOC1">ONCE-ONLY SUBPATTERNS</A>
-<P>
-With both maximizing and minimizing repetition, failure of what follows
-normally causes the repeated item to be re-evaluated to see if a different
-number of repeats allows the rest of the pattern to match. Sometimes it is
-useful to prevent this, either to change the nature of the match, or to cause
-it fail earlier than it otherwise might, when the author of the pattern knows
-there is no point in carrying on.
-</P>
-<P>
-Consider, for example, the pattern \d+foo when applied to the subject line
-</P>
-<P>
-<PRE>
-  123456bar
-</PRE>
-</P>
-<P>
-After matching all 6 digits and then failing to match "foo", the normal
-action of the matcher is to try again with only 5 digits matching the \d+
-item, and then with 4, and so on, before ultimately failing. Once-only
-subpatterns provide the means for specifying that once a portion of the pattern
-has matched, it is not to be re-evaluated in this way, so the matcher would
-give up immediately on failing to match "foo" the first time. The notation is
-another kind of special parenthesis, starting with (?&#62; as in this example:
-</P>
-<P>
-<PRE>
-  (?&#62;\d+)bar
-</PRE>
-</P>
-<P>
-This kind of parenthesis "locks up" the  part of the pattern it contains once
-it has matched, and a failure further into the pattern is prevented from
-backtracking into it. Backtracking past it to previous items, however, works as
-normal.
-</P>
-<P>
-An alternative description is that a subpattern of this type matches the string
-of characters that an identical standalone pattern would match, if anchored at
-the current point in the subject string.
-</P>
-<P>
-Once-only subpatterns are not capturing subpatterns. Simple cases such as the
-above example can be thought of as a maximizing repeat that must swallow
-everything it can. So, while both \d+ and \d+? are prepared to adjust the
-number of digits they match in order to make the rest of the pattern match,
-(?&#62;\d+) can only match an entire sequence of digits.
-</P>
-<P>
-This construction can of course contain arbitrarily complicated subpatterns,
-and it can be nested.
-</P>
-<P>
-Once-only subpatterns can be used in conjunction with lookbehind assertions to
-specify efficient matching at the end of the subject string. Consider a simple
-pattern such as
-</P>
-<P>
-<PRE>
-  abcd$
-</PRE>
-</P>
-<P>
-when applied to a long string which does not match it. Because matching
-proceeds from left to right, PCRE will look for each "a" in the subject and
-then see if what follows matches the rest of the pattern. If the pattern is
-specified as
-</P>
-<P>
-<PRE>
-  ^.*abcd$
-</PRE>
-</P>
-<P>
-then the initial .* matches the entire string at first, but when this fails, it
-backtracks to match all but the last character, then all but the last two
-characters, and so on. Once again the search for "a" covers the entire string,
-from right to left, so we are no better off. However, if the pattern is written
-as
-</P>
-<P>
-<PRE>
-  ^(?&#62;.*)(?&#60;=abcd)
-</PRE>
-</P>
-<P>
-then there can be no backtracking for the .* item; it can match only the entire
-string. The subsequent lookbehind assertion does a single test on the last four
-characters. If it fails, the match fails immediately. For long strings, this
-approach makes a significant difference to the processing time.
-</P>
-<LI><A NAME="SEC25" HREF="#TOC1">CONDITIONAL SUBPATTERNS</A>
-<P>
-It is possible to cause the matching process to obey a subpattern
-conditionally or to choose between two alternative subpatterns, depending on
-the result of an assertion, or whether a previous capturing subpattern matched
-or not. The two possible forms of conditional subpattern are
-</P>
-<P>
-<PRE>
+It is possible to cause the matching process to obey a pattern fragment
+conditionally or to choose between two alternative fragments, depending on
+the result of an assertion, or whether a specific capture group has
+already been matched. The two possible forms of conditional group are:
+<pre>
   (?(condition)yes-pattern)
   (?(condition)yes-pattern|no-pattern)
-</PRE>
-</P>
-<P>
+</pre>
 If the condition is satisfied, the yes-pattern is used; otherwise the
-no-pattern (if present) is used. If there are more than two alternatives in the
-subpattern, a compile-time error occurs.
-</P>
-<P>
-There are two kinds of condition. If the text between the parentheses consists
-of a sequence of digits, then the condition is satisfied if the capturing
-subpattern of that number has previously matched. Consider the following
-pattern, which contains non-significant white space to make it more readable
-(assume the "x" PCRE_EXTENDED option) and to divide it into three parts for ease
-of discussion:
-</P>
-<P>
-<PRE>
-  ( \( )?    [^()]+    (?(1) \) )
+no-pattern (if present) is used. An absent no-pattern is equivalent to an empty
+string (it always matches). If there are more than two alternatives in the
+group, a compile-time error occurs. Each of the two alternatives may itself
+contain nested groups of any form, including conditional groups; the
+restriction to two alternatives applies only at the level of the condition
+itself. This pattern fragment is an example where the alternatives are complex:
+<pre>
+  (?(1) (A|B|C) | (D | (?(2)E|F) | E) )
+
 </PRE>
 </P>
 <P>
+There are five kinds of condition: references to capture groups, references to
+recursion, two pseudo-conditions called DEFINE and VERSION, and assertions.
+</P>
+<br><b>
+Checking for a used capture group by number
+</b><br>
+<P>
+If the text between the parentheses consists of a sequence of digits, the
+condition is true if a capture group of that number has previously matched. If
+there is more than one capture group with the same number (see the earlier
+<a href="#recursion">section about duplicate group numbers),</a>
+the condition is true if any of them have matched. An alternative notation,
+which is a PCRE2 extension, not supported by Perl, is to precede the digits
+with a plus or minus sign. In this case, the group number is relative rather
+than absolute. The most recently opened capture group (which could be enclosing
+this condition) can be referenced by (?(-1), the next most recent by (?(-2),
+and so on. Inside loops it can also make sense to refer to subsequent groups.
+The next capture group to be opened can be referenced as (?(+1), and so on. The
+value zero in any of these forms is not used; it provokes a compile-time error.
+</P>
+<P>
+Consider the following pattern, which contains non-significant white space to
+make it more readable (assume the PCRE2_EXTENDED option) and to divide it into
+three parts for ease of discussion:
+<pre>
+  ( \( )?    [^()]+    (?(1) \) )
+</pre>
 The first part matches an optional opening parenthesis, and if that
 character is present, sets it as the first captured substring. The second part
 matches one or more characters that are not parentheses. The third part is a
-conditional subpattern that tests whether the first set of parentheses matched
-or not. If they did, that is, if subject started with an opening parenthesis,
+conditional group that tests whether or not the first capture group
+matched. If it did, that is, if subject started with an opening parenthesis,
 the condition is true, and so the yes-pattern is executed and a closing
 parenthesis is required. Otherwise, since no-pattern is not present, the
-subpattern matches nothing. In other words, this pattern matches a sequence of
-non-parentheses, optionally enclosed in parentheses.
+conditional group matches nothing. In other words, this pattern matches a
+sequence of non-parentheses, optionally enclosed in parentheses.
 </P>
 <P>
-If the condition is not a sequence of digits, it must be an assertion. This may
-be a positive or negative lookahead or lookbehind assertion. Consider this
-pattern, again containing non-significant white space, and with the two
-alternatives on the second line:
+If you were embedding this pattern in a larger one, you could use a relative
+reference:
+<pre>
+  ...other stuff... ( \( )?    [^()]+    (?(-1) \) ) ...
+</pre>
+This makes the fragment independent of the parentheses in the larger pattern.
+</P>
+<br><b>
+Checking for a used capture group by name
+</b><br>
+<P>
+Perl uses the syntax (?(&#60;name&#62;)...) or (?('name')...) to test for a used
+capture group by name. For compatibility with earlier versions of PCRE1, which
+had this facility before Perl, the syntax (?(name)...) is also recognized.
+Note, however, that undelimited names consisting of the letter R followed by
+digits are ambiguous (see the following section). Rewriting the above example
+to use a named group gives this:
+<pre>
+  (?&#60;OPEN&#62; \( )?    [^()]+    (?(&#60;OPEN&#62;) \) )
+</pre>
+If the name used in a condition of this kind is a duplicate, the test is
+applied to all groups of the same name, and is true if any one of them has
+matched.
+</P>
+<br><b>
+Checking for pattern recursion
+</b><br>
+<P>
+"Recursion" in this sense refers to any subroutine-like call from one part of
+the pattern to another, whether or not it is actually recursive. See the
+sections entitled
+<a href="#recursion">"Recursive patterns"</a>
+and
+<a href="#groupsassubroutines">"Groups as subroutines"</a>
+below for details of recursion and subroutine calls.
 </P>
 <P>
-<PRE>
+If a condition is the string (R), and there is no capture group with the name
+R, the condition is true if matching is currently in a recursion or subroutine
+call to the whole pattern or any capture group. If digits follow the letter R,
+and there is no group with that name, the condition is true if the most recent
+call is into a group with the given number, which must exist somewhere in the
+overall pattern. This is a contrived example that is equivalent to a+b:
+<pre>
+  ((?(R1)a+|(?1)b))
+</pre>
+However, in both cases, if there is a capture group with a matching name, the
+condition tests for its being set, as described in the section above, instead
+of testing for recursion. For example, creating a group with the name R1 by
+adding (?&#60;R1&#62;) to the above pattern completely changes its meaning.
+</P>
+<P>
+If a name preceded by ampersand follows the letter R, for example:
+<pre>
+  (?(R&name)...)
+</pre>
+the condition is true if the most recent recursion is into a group of that name
+(which must exist within the pattern).
+</P>
+<P>
+This condition does not check the entire recursion stack. It tests only the
+current level. If the name used in a condition of this kind is a duplicate, the
+test is applied to all groups of the same name, and is true if any one of
+them is the most recent recursion.
+</P>
+<P>
+At "top level", all these recursion test conditions are false.
+<a name="subdefine"></a></P>
+<br><b>
+Defining capture groups for use by reference only
+</b><br>
+<P>
+If the condition is the string (DEFINE), the condition is always false, even if
+there is a group with the name DEFINE. In this case, there may be only one
+alternative in the rest of the conditional group. It is always skipped if
+control reaches this point in the pattern; the idea of DEFINE is that it can be
+used to define subroutines that can be referenced from elsewhere. (The use of
+<a href="#groupsassubroutines">subroutines</a>
+is described below.) For example, a pattern to match an IPv4 address such as
+"192.168.23.245" could be written like this (ignore white space and line
+breaks):
+<pre>
+  (?(DEFINE) (?&#60;byte&#62; 2[0-4]\d | 25[0-5] | 1\d\d | [1-9]?\d) )
+  \b (?&byte) (\.(?&byte)){3} \b
+</pre>
+The first part of the pattern is a DEFINE group inside which another group
+named "byte" is defined. This matches an individual component of an IPv4
+address (a number less than 256). When matching takes place, this part of the
+pattern is skipped because DEFINE acts like a false condition. The rest of the
+pattern uses references to the named group to match the four dot-separated
+components of an IPv4 address, insisting on a word boundary at each end.
+</P>
+<br><b>
+Checking the PCRE2 version
+</b><br>
+<P>
+Programs that link with a PCRE2 library can check the version by calling
+<b>pcre2_config()</b> with appropriate arguments. Users of applications that do
+not have access to the underlying code cannot do this. A special "condition"
+called VERSION exists to allow such users to discover which version of PCRE2
+they are dealing with by using this condition to match a string such as
+"yesno". VERSION must be followed either by "=" or "&#62;=" and a version number.
+For example:
+<pre>
+  (?(VERSION&#62;=10.4)yes|no)
+</pre>
+This pattern matches "yes" if the PCRE2 version is greater or equal to 10.4, or
+"no" otherwise. The fractional part of the version number may not contain more
+than two digits.
+</P>
+<br><b>
+Assertion conditions
+</b><br>
+<P>
+If the condition is not in any of the above formats, it must be a parenthesized
+assertion. This may be a positive or negative lookahead or lookbehind
+assertion. However, it must be a traditional atomic assertion, not one of the
+<a href="#nonatomicassertions">non-atomic assertions.</a>
+</P>
+<P>
+Consider this pattern, again containing non-significant white space, and with
+the two alternatives on the second line:
+<pre>
   (?(?=[^a-z]*[a-z])
-  \d{2}[a-z]{3}-\d{2}  |  \d{2}-\d{2}-\d{2} )
-</PRE>
-</P>
-<P>
+  \d{2}-[a-z]{3}-\d{2}  |  \d{2}-\d{2}-\d{2} )
+</pre>
 The condition is a positive lookahead assertion that matches an optional
 sequence of non-letters followed by a letter. In other words, it tests for the
 presence of at least one letter in the subject. If a letter is found, the
@@ -1107,109 +1260,277 @@ subject is matched against the first alternative; otherwise it is matched
 against the second. This pattern matches strings in one of the two forms
 dd-aaa-dd or dd-dd-dd, where aaa are letters and dd are digits.
 </P>
-<LI><A NAME="SEC26" HREF="#TOC1">COMMENTS</A>
 <P>
-The sequence (?# marks the start of a comment which continues up to the next
-closing parenthesis. Nested parentheses are not permitted. The characters
-that make up a comment play no part in the pattern matching at all.
+When an assertion that is a condition contains capture groups, any
+capturing that occurs in a matching branch is retained afterwards, for both
+positive and negative assertions, because matching always continues after the
+assertion, whether it succeeds or fails. (Compare non-conditional assertions,
+for which captures are retained only for positive assertions that succeed.)
+<LI><a name="SEC28" href="#TOC1">RECURSIVE PATTERNS</a><br>
+<P>
+Consider the problem of matching a string in parentheses, allowing for
+unlimited nested parentheses. Without the use of recursion, the best that can
+be done is to use a pattern that matches up to some fixed depth of nesting. It
+is not possible to handle an arbitrary nesting depth.
 </P>
 <P>
-If the "x" PCRE_EXTENDED option is set, an unescaped # character outside a
-character class introduces a comment that continues up to the next newline
-character in the pattern.
-</P>
-<LI><A NAME="SEC27" HREF="#TOC1">PERFORMANCE</A>
-<P>
-Certain items that may appear in patterns are more efficient than others. It is
-more efficient to use a character class like [aeiou] than a set of alternatives
-such as (a|e|i|o|u). In general, the simplest construction that provides the
-required behaviour is usually the most efficient. Jeffrey Friedl's book
-contains a lot of discussion about optimizing regular expressions for efficient
-performance.
-</P>
-<!--
-<P>
-When a pattern begins with .* and the PCRE_DOTALL option is set, the pattern is
-implicitly anchored by PCRE, since it can match only at the start of a subject
-string. However, if PCRE_DOTALL is not set, PCRE cannot make this optimization,
-because the . metacharacter does not then match a newline, and if the subject
-string contains newlines, the pattern may match from the character immediately
-following one of them instead of from the very start. For example, the pattern
+For some time, Perl has provided a facility that allows regular expressions to
+recurse (amongst other things). It does this by interpolating Perl code in the
+expression at run time, and the code can refer to the expression itself. A Perl
+pattern using code interpolation to solve the parentheses problem can be
+created like this:
+<pre>
+  $re = qr{\( (?: (?&#62;[^()]+) | (?p{$re}) )* \)}x;
+</pre>
+The (?p{...}) item interpolates Perl code at run time, and in this case refers
+recursively to the pattern in which it appears.
 </P>
 <P>
-<PRE>
-  (.*) second
-</PRE>
+Obviously, PCRE2 cannot support the interpolation of Perl code. Instead, it
+supports special syntax for recursion of the entire pattern, and also for
+individual capture group recursion. After its introduction in PCRE1 and Python,
+this kind of recursion was subsequently introduced into Perl at release 5.10.
 </P>
 <P>
-matches the subject "first\nand second" (where \n stands for a newline
-character) with the first captured substring being "and". In order to do this,
-PCRE has to retry the match starting after every newline in the subject.
+A special item that consists of (? followed by a number greater than zero and a
+closing parenthesis is a recursive subroutine call of the capture group of the
+given number, provided that it occurs inside that group. (If not, it is a
+<a href="#groupsassubroutines">non-recursive subroutine</a>
+call, which is described in the next section.) The special item (?R) or (?0) is
+a recursive call of the entire regular expression.
 </P>
 <P>
-If you are using such a pattern with subject strings that do not contain
-newlines, the best performance is obtained by setting PCRE_DOTALL, or starting
-the pattern with ^.* to indicate explicit anchoring. That saves PCRE from
-having to scan along the subject looking for a newline to restart at.
-</P>
--->
-<P>
-Beware of patterns that contain nested indefinite repeats. These can take a
-long time to run when applied to a string that does not match. Consider the
-pattern fragment
-</P>
-<P>
-<PRE>
-  (a+)*
-</PRE>
+This PCRE2 pattern solves the nested parentheses problem (assume the
+PCRE2_EXTENDED option is set so that white space is ignored):
+<pre>
+  \( ( [^()]++ | (?R) )* \)
+</pre>
+First it matches an opening parenthesis. Then it matches any number of
+substrings which can either be a sequence of non-parentheses, or a recursive
+match of the pattern itself (that is, a correctly parenthesized substring).
+Finally there is a closing parenthesis. Note the use of a possessive quantifier
+to avoid backtracking into sequences of non-parentheses.
 </P>
 <P>
-This can match "aaaa" in 33 different ways, and this number increases very
-rapidly as the string gets longer. (The * repeat can match 0, 1, 2, 3, or 4
-times, and for each of those cases other than 0, the + repeats can match
-different numbers of times.) When the remainder of the pattern is such that the
-entire match is going to fail, PCRE has in principle to try every possible
-variation, and this can take an extremely long time.
+If this were part of a larger pattern, you would not want to recurse the entire
+pattern, so instead you could use this:
+<pre>
+  ( \( ( [^()]++ | (?1) )* \) )
+</pre>
+We have put the pattern into parentheses, and caused the recursion to refer to
+them instead of the whole pattern.
 </P>
 <P>
-An optimization catches some of the more simple cases such as
+In a larger pattern, keeping track of parenthesis numbers can be tricky. This
+is made easier by the use of relative references. Instead of (?1) in the
+pattern above you can write (?-2) to refer to the second most recently opened
+parentheses preceding the recursion. In other words, a negative number counts
+capturing parentheses leftwards from the point at which it is encountered.
 </P>
 <P>
-<PRE>
-  (a+)*b
-</PRE>
+Be aware however, that if
+<a href="#dupgroupnumber">duplicate capture group numbers</a>
+are in use, relative references refer to the earliest group with the
+appropriate number. Consider, for example:
+<pre>
+  (?|(a)|(b)) (c) (?-2)
+</pre>
+The first two capture groups (a) and (b) are both numbered 1, and group (c)
+is number 2. When the reference (?-2) is encountered, the second most recently
+opened parentheses has the number 1, but it is the first such group (the (a)
+group) to which the recursion refers. This would be the same if an absolute
+reference (?1) was used. In other words, relative references are just a
+shorthand for computing a group number.
 </P>
 <P>
-where a literal character follows. Before embarking on the standard matching
-procedure, PCRE checks that there is a "b" later in the subject string, and if
-there is not, it fails the match immediately. However, when there is no
-following literal this optimization cannot be used. You can see the difference
-by comparing the behaviour of
+It is also possible to refer to subsequent capture groups, by writing
+references such as (?+2). However, these cannot be recursive because the
+reference is not inside the parentheses that are referenced. They are always
+<a href="#groupsassubroutines">non-recursive subroutine</a>
+calls, as described in the next section.
 </P>
 <P>
-<PRE>
-  (a+)*\d
-</PRE>
+An alternative approach is to use named parentheses. The Perl syntax for this
+is (?&name); PCRE1's earlier syntax (?P&#62;name) is also supported. We could
+rewrite the above example as follows:
+<pre>
+  (?&#60;pn&#62; \( ( [^()]++ | (?&pn) )* \) )
+</pre>
+If there is more than one group with the same name, the earliest one is
+used.
 </P>
 <P>
-with the pattern above. The former gives a failure almost instantly when
-applied to a whole line of "a" characters, whereas the latter takes an
-appreciable time with strings longer than about 20 characters.
-</P>
-<LI><A NAME="SEC28" HREF="#TOC1">AUTHOR</A>
-<P>
-Philip Hazel &#60;ph10@cam.ac.uk&#62;
-<BR>
-University Computing Service,
-<BR>
-New Museums Site,
-<BR>
-Cambridge CB2 3QG, England.
-<BR>
-Phone: +44 1223 334714
+The example pattern that we have been looking at contains nested unlimited
+repeats, and so the use of a possessive quantifier for matching strings of
+non-parentheses is important when applying the pattern to strings that do not
+match. For example, when this pattern is applied to
+<pre>
+  (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa()
+</pre>
+it yields "no match" quickly. However, if a possessive quantifier is not used,
+the match runs for a very long time indeed because there are so many different
+ways the + and * repeats can carve up the subject, and all have to be tested
+before failure can be reported.
 </P>
 <P>
-Last updated: 29 July 1999
-<BR>
-Copyright (c) 1997-1999 University of Cambridge.
+At the end of a match, the values of capturing parentheses are those from
+the outermost level. If you want to obtain intermediate values, a callout
+function can be used (see below and the
+<a href="pcre2callout.html"><b>pcre2callout</b></a>
+documentation). If the pattern above is matched against
+<pre>
+  (ab(cd)ef)
+</pre>
+the value for the inner capturing parentheses (numbered 2) is "ef", which is
+the last value taken on at the top level. If a capture group is not matched at
+the top level, its final captured value is unset, even if it was (temporarily)
+set at a deeper level during the matching process.
+</P>
+<P>
+Do not confuse the (?R) item with the condition (R), which tests for recursion.
+Consider this pattern, which matches text in angle brackets, allowing for
+arbitrary nesting. Only digits are allowed in nested brackets (that is, when
+recursing), whereas any characters are permitted at the outer level.
+<pre>
+  &#60; (?: (?(R) \d++  | [^&#60;&#62;]*+) | (?R)) * &#62;
+</pre>
+In this pattern, (?(R) is the start of a conditional group, with two different
+alternatives for the recursive and non-recursive cases. The (?R) item is the
+actual recursive call.
+<a name="recursiondifference"></a></P>
+<br><b>
+Differences in recursion processing between PCRE2 and Perl
+</b><br>
+<P>
+Some former differences between PCRE2 and Perl no longer exist.
+</P>
+<P>
+Before release 10.30, recursion processing in PCRE2 differed from Perl in that
+a recursive subroutine call was always treated as an atomic group. That is,
+once it had matched some of the subject string, it was never re-entered, even
+if it contained untried alternatives and there was a subsequent matching
+failure. (Historical note: PCRE implemented recursion before Perl did.)
+</P>
+<P>
+Starting with release 10.30, recursive subroutine calls are no longer treated
+as atomic. That is, they can be re-entered to try unused alternatives if there
+is a matching failure later in the pattern. This is now compatible with the way
+Perl works. If you want a subroutine call to be atomic, you must explicitly
+enclose it in an atomic group.
+</P>
+<P>
+Supporting backtracking into recursions simplifies certain types of recursive
+pattern. For example, this pattern matches palindromic strings:
+<pre>
+  ^((.)(?1)\2|.?)$
+</pre>
+The second branch in the group matches a single central character in the
+palindrome when there are an odd number of characters, or nothing when there
+are an even number of characters, but in order to work it has to be able to try
+the second case when the rest of the pattern match fails. If you want to match
+typical palindromic phrases, the pattern has to ignore all non-word characters,
+which can be done like this:
+<pre>
+  ^\W*+((.)\W*+(?1)\W*+\2|\W*+.?)\W*+$
+</pre>
+If run with the PCRE2_CASELESS option, this pattern matches phrases such as "A
+man, a plan, a canal: Panama!". Note the use of the possessive quantifier *+ to
+avoid backtracking into sequences of non-word characters. Without this, PCRE2
+takes a great deal longer (ten times or more) to match typical phrases, and
+Perl takes so long that you think it has gone into a loop.
+</P>
+<P>
+Another way in which PCRE2 and Perl used to differ in their recursion
+processing is in the handling of captured values. Formerly in Perl, when a
+group was called recursively or as a subroutine (see the next section), it
+had no access to any values that were captured outside the recursion, whereas
+in PCRE2 these values can be referenced. Consider this pattern:
+<pre>
+  ^(.)(\1|a(?2))
+</pre>
+This pattern matches "bab". The first capturing parentheses match "b", then in
+the second group, when the backreference \1 fails to match "b", the second
+alternative matches "a" and then recurses. In the recursion, \1 does now match
+"b" and so the whole match succeeds. This match used to fail in Perl, but in
+later versions (I tried 5.024) it now works.
+<LI><br><a name="SEC29" href="#TOC1">GROUPS AS SUBROUTINES</a><br>
+<P>
+If the syntax for a recursive group call (either by number or by name) is used
+outside the parentheses to which it refers, it operates a bit like a subroutine
+in a programming language. More accurately, PCRE2 treats the referenced group
+as an independent subpattern which it tries to match at the current matching
+position. The called group may be defined before or after the reference. A
+numbered reference can be absolute or relative, as in these examples:
+<pre>
+  (...(absolute)...)...(?2)...
+  (...(relative)...)...(?-1)...
+  (...(?+1)...(relative)...
+</pre>
+An earlier example pointed out that the pattern
+<pre>
+  (sens|respons)e and \1ibility
+</pre>
+matches "sense and sensibility" and "response and responsibility", but not
+"sense and responsibility". If instead the pattern
+<pre>
+  (sens|respons)e and (?1)ibility
+</pre>
+is used, it does match "sense and responsibility" as well as the other two
+strings. Another example is given in the discussion of DEFINE above.
+</P>
+<P>
+Like recursions, subroutine calls used to be treated as atomic, but this
+changed at PCRE2 release 10.30, so backtracking into subroutine calls can now
+occur. However, any capturing parentheses that are set during the subroutine
+call revert to their previous values afterwards.
+</P>
+<P>
+Processing options such as case-independence are fixed when a group is
+defined, so if it is used as a subroutine, such options cannot be changed for
+different calls. For example, consider this pattern:
+<pre>
+  (abc)(?i:(?-1))
+</pre>
+It matches "abcabc". It does not match "abcABC" because the change of
+processing option does not affect the called group.
+</P>
+<P>
+The behaviour of
+<a href="#backtrackcontrol">backtracking control verbs</a>
+in groups when called as subroutines is described in the section entitled
+<a href="#btsub">"Backtracking verbs in subroutines"</a> in the PCRE2 documentation.
+<!-- <a name="onigurumasubroutines"></a></P>
+<br><a name="SEC30" href="#TOC1">ONIGURUMA SUBROUTINE SYNTAX</a><br>
+<P>
+For compatibility with Oniguruma, the non-Perl syntax \g followed by a name or
+a number enclosed either in angle brackets or single quotes, is an alternative
+syntax for calling a group as a subroutine, possibly recursively. Here are two
+of the examples used above, rewritten using this syntax:
+<pre>
+  (?&#60;pn&#62; \( ( (?&#62;[^()]+) | \g&#60;pn&#62; )* \) )
+  (sens|respons)e and \g'1'ibility
+</pre>
+PCRE2 supports an extension to Oniguruma: if a number is preceded by a
+plus or a minus sign it is taken as a relative reference. For example:
+<pre>
+  (abc)(?i:\g&#60;-1&#62;)
+</pre>
+Note that \g{...} (Perl syntax) and \g&#60;...&#62; (Oniguruma syntax) are <i>not</i>
+synonymous. The former is a backreference; the latter is a subroutine call.
+</P>-->
+<LI><a name="SEC35" href="#TOC1">AUTHOR</a><br>
+<P>
+Philip Hazel
+<br>
+Retired from University Computing Service
+<br>
+Cambridge, England.
+<br>
+</P>
+<br><a name="SEC36" href="#TOC1">REVISION</a><br>
+<P>
+Last updated: 27 November 2024
+<br>
+Copyright &copy; 1997-2024 University of Cambridge.
+<br>
 </UL>

--- a/src/macro.c
+++ b/src/macro.c
@@ -900,8 +900,8 @@ static int complete_macro(Macro *spec, unsigned int hash, int num,
     }
     spec->attr &= ~F_NONE;
     if (spec->nsubattr) {
-	int n;
-    pcre_fullinfo(spec->trig.ri->re, NULL, PCRE_INFO_CAPTURECOUNT, &n);
+    uint32_t n = 0;
+    pcre2_pattern_info(spec->trig.ri->re, PCRE2_INFO_CAPTURECOUNT, &n);
 	for (i = 0; i < spec->nsubattr; i++) {
 	    spec->subattr[i].attr &= ~F_NONE;
 	    if (spec->subattr[i].subexp > n) {
@@ -1840,7 +1840,7 @@ static void apply_attrs_of_match(
     {
 	int i, x, offset = 0;
 	int start, end;
-	int *saved_ovector = NULL;
+	PCRE2_SIZE *saved_ovector = NULL;
 
 	if (text)
 	    old = new_reg_scope(ri, text);

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,7 @@
 #include "expand.h"
 #include "expr.h"
 #include "process.h"
+#include "malloc.h"
 
 extern struct World   *world_decl;     /* declares struct World */
 
@@ -74,6 +75,8 @@ int main(int argc, char *argv[])
     int worldflag = TRUE;
     int autologin = -1, quietlogin = -1, autovisual = TRUE;
     String *scratch;
+    char *pcre_version;
+    int pcre_version_length;
 
     puts("");
     puts(version);
@@ -160,7 +163,12 @@ int main(int argc, char *argv[])
     oputs("Type `/help copyright' for more information.");
     if (*contrib) oputs(contrib);
     if (*mods) oputs(mods);
-    oprintf("Using PCRE version %s", pcre_version());
+    pcre_version_length = pcre2_config(PCRE2_CONFIG_VERSION, NULL);
+    pcre_version = XMALLOC(pcre_version_length + 1);
+    pcre_version[0] = '\0';
+    pcre2_config(PCRE2_CONFIG_VERSION, pcre_version);
+    oprintf("Using PCRE version %s", pcre_version);
+    FREE(pcre_version);
     oputs("Type `/help', `/help topics', or `/help intro' for help.");
     oputs("Type `/quit' to quit tf.");
     oputs("");

--- a/src/pattern.h
+++ b/src/pattern.h
@@ -8,15 +8,15 @@
 
 #ifndef PATTERN_H
 #define PATTERN_H
+#define PCRE2_CODE_UNIT_WIDTH 8
 
-#include <pcre.h>
+#include <pcre2.h>
 
 typedef struct RegInfo {
-    pcre *re;
-    pcre_extra *extra;
+    pcre2_code *re;
     conString *Str;
     int links;
-    int *ovector;
+    PCRE2_SIZE *ovector;
     int ovecsize;
 } RegInfo;
 

--- a/src/tfpython.c
+++ b/src/tfpython.c
@@ -201,7 +201,7 @@ static struct Value* pyvar_to_tfvar( PyObject *pRc )
 {
 	struct Value *rc;
 	char *cstr;
-	int len; // Py_ssize_t len;
+	long int len; // Py_ssize_t len;
 
 	// can be null if exception was thrown
 	if( !pRc ) {

--- a/src/tfpython.c
+++ b/src/tfpython.c
@@ -401,7 +401,7 @@ struct Value *handle_python_call_command( String *args, int offset )
 	// Okay, so now it's callable, give it the string.
 	// We go through all this because otherwise the quoting problem is insane.
 	arglist = Py_BuildValue( "(s)", argstr );
-	pRc = PyEval_CallObject( function, arglist );
+	pRc = PyObject_CallObject( function, arglist );
 
 bail:
 	Py_XDECREF( function );

--- a/unix/unix.mak
+++ b/unix/unix.mak
@@ -191,7 +191,7 @@ tags: *.[ch]
 
 dep: *.c
 	gcc -E -MM *.c \
-		| sed 's;pcre[^ ]*/pcre.h ;;' \
+		| sed 's;pcre[^ ]*/pcre2.h ;;' \
 		| sed '/[^\\]$$/s/$$/ $$(BUILDERS)/' \
 		> dep
 


### PR DESCRIPTION
Implemented the [patches from Debian](https://sources.debian.org/patches/tf5/5.0beta8-14/0011-Port-to-PCRE2.patch/) to compile with PCRE2. Revisions to pcre.html and patterns.html. This is *not* backwards compatible with PCRE, and will therefore make the default minimum requirements PCRE2.

Encountered issue compiling  within Python 3.13, and corrected the minor issue.

Compiles without issue on RockyLinux (RHEL derivative) and Debian. Errors on base Archlinux due to default CFLAGS.

I have been using it without issue for 2 weeks.