### PR TITLE
Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8','3.10', '3.12']
+        python-version: ['3.10', '3.12', '3.13']
         opts:
           - "--enable-lua"
           - "--enable-python"
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8','3.10', '3.12']
+        python-version: ['3.12', '3.13']
         opts:
 #          - "--enable-lua"
           - "--enable-python"
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install packages on MacOS
         run: |
-          brew install lua pcre python@${{ matrix.python-version }}
+          brew install lua pcre2 python@${{ matrix.python-version }}
           echo "/usr/local/opt/python@${{ matrix.python-version }}/bin" >> $GITHUB_PATH
       - name: Configure
         run: ./configure --enable-version --enable-symlink --enable-atcp --enable-gmcp --enable-option102 ${{ matrix.opts }}


### PR DESCRIPTION
This pull request updates the Python versions used in the CI workflows and adjusts package installations to align with the changes. The most important changes include removing support for Python 3.8, adding support for Python 3.13, and switching from `pcre` to `pcre2` for package installation on macOS.
