### PR TITLE
New hook "GMCP_LOGIN" added to be used as a trigger for sending Char.Login

### DIFF
--- a/htmldoc/topics/hooks.html
+++ b/htmldoc/topics/hooks.html
@@ -107,6 +107,9 @@
                                 (Called if you send the server's disconnect
                                 command (e.g., "QUIT") or <a href="../topics/sockets.html">socket</a> closes, but
                                 not if you use <a href="../commands/dc.html">/dc</a>.)
+<a name="GMCP_LOGIN"></a><!--
+---- -->  GMCP_LOGIN  world             (GMCP subnegotiation after connecting. Useful 
+                                for sending Char.Login message to server.)
 <a name="KILL"></a><!--
 ---- -->  KILL        pid               (<a href="../topics/processes.html">process</a> ends)
 <a name="LOAD"></a><!--

--- a/lib/tf/tf-help
+++ b/lib/tf/tf-help
@@ -5833,6 +5833,9 @@ hooks
                                   (Called if you send the server's disconnect
                                   command (e.g., "QUIT") or [1msocket[22;0m closes, but
                                   not if you use [1m/dc[22;0m.)
+#GMCP_LOGIN
+    GMCP_LOGIN  world             (GMCP subnegotiation after connecting. Useful 
+                                  for sending Char.Login message to server.)
 #KILL
     KILL        pid               ([1mprocess[22;0m ends)
 #LOAD

--- a/src/hooklist.h
+++ b/src/hooklist.h
@@ -23,6 +23,7 @@ gencode(CONNECT,	HT_WORLD | HT_XSOCK),
 gencode(DISCONNECT,	HT_WORLD | HT_XSOCK),
 #if ENABLE_GMCP
 gencode(GMCP,		0),
+gencode(GMCP_LOGIN, 0),
 #endif
 gencode(ICONFAIL,	HT_WORLD | HT_XSOCK),
 gencode(KILL,		0),

--- a/src/socket.c
+++ b/src/socket.c
@@ -3632,6 +3632,11 @@ static int handle_socket_input(const char *simbuffer, int simlen, const char *en
                         CLR_TELOPT(xsock, them_tog, rawchar);  /* done */
                     } else {
                         DO(rawchar);  /* acknowledge their request */
+                        #if ENABLE_GMCP
+                            if (rawchar == TN_GMCP && gmcp) {
+                                do_hook(H_GMCP_LOGIN, NULL, "%s", xsock->world->name);
+                            }
+                        #endif
                     }
                 } else {
                     DONT(rawchar);    /* refuse their request */


### PR DESCRIPTION
This is a small QoL addition. When connecting, and wanting to send Char.Login to some servers, there's not always a clear time when that should be done.

This hook provides a mechanism to trigger sending Char.Login with the appropriate parameters to the server.